### PR TITLE
[DOP-20135] Add search filter to dataset & job grids

### DIFF
--- a/src/components/dataset/DatasetGrid.tsx
+++ b/src/components/dataset/DatasetGrid.tsx
@@ -1,17 +1,36 @@
 import { ReactElement } from "react";
-import { List, Datagrid, TextField, WrapperField } from "react-admin";
+import {
+    List,
+    TextField,
+    WrapperField,
+    TopToolbar,
+    SelectColumnsButton,
+    DatagridConfigurable,
+    SearchInput,
+    minLength,
+} from "react-admin";
 import DatasetLocationIcon from "./DatasetLocationIcon";
+
+const DatasetGridActions = () => (
+    <TopToolbar>
+        <SelectColumnsButton />
+    </TopToolbar>
+);
+
+const datasetFilters = [
+    <SearchInput source="search_query" alwaysOn validate={minLength(3)} />,
+];
 
 const DatasetGrid = (): ReactElement => {
     return (
-        <List>
-            <Datagrid bulkActionButtons={false}>
-                <WrapperField source="location.type">
+        <List actions={<DatasetGridActions />} filters={datasetFilters}>
+            <DatagridConfigurable bulkActionButtons={false}>
+                <WrapperField source="location.type" sortable={false}>
                     <DatasetLocationIcon />
                 </WrapperField>
-                <TextField source="location.name" />
-                <TextField source="name" />
-            </Datagrid>
+                <TextField source="location.name" sortable={false} />
+                <TextField source="name" sortable={false} />
+            </DatagridConfigurable>
         </List>
     );
 };

--- a/src/components/job/JobGrid.tsx
+++ b/src/components/job/JobGrid.tsx
@@ -1,21 +1,40 @@
 import { ReactElement } from "react";
-import { List, Datagrid, TextField, WrapperField } from "react-admin";
+import {
+    List,
+    TextField,
+    WrapperField,
+    TopToolbar,
+    SelectColumnsButton,
+    SearchInput,
+    minLength,
+    DatagridConfigurable,
+} from "react-admin";
 import JobIcon from "./JobIcon";
 import JobLocationIcon from "./JobLocationIcon";
 
+const JobGridActions = () => (
+    <TopToolbar>
+        <SelectColumnsButton />
+    </TopToolbar>
+);
+
+const jobFilters = [
+    <SearchInput source="search_query" alwaysOn validate={minLength(3)} />,
+];
+
 const JobGrid = (): ReactElement => {
     return (
-        <List>
-            <Datagrid bulkActionButtons={false}>
-                <WrapperField source="type">
+        <List actions={<JobGridActions />} filters={jobFilters}>
+            <DatagridConfigurable bulkActionButtons={false}>
+                <WrapperField source="type" sortable={false}>
                     <JobIcon />
                 </WrapperField>
-                <TextField source="name" />
-                <WrapperField source="location.type">
+                <TextField source="name" sortable={false} />
+                <WrapperField source="location.type" sortable={false}>
                     <JobLocationIcon />
                 </WrapperField>
-                <TextField source="location.name" />
-            </Datagrid>
+                <TextField source="location.name" sortable={false} />
+            </DatagridConfigurable>
         </List>
     );
 };

--- a/src/dataProvider/index.ts
+++ b/src/dataProvider/index.ts
@@ -32,6 +32,12 @@ const defaultDataProvider: DataProvider = {
             );
         }
 
+        if (params.filter) {
+            for (const field in params.filter) {
+                url.searchParams.append(field, params.filter[field]);
+            }
+        }
+
         return new Promise((resolve, reject) => {
             return fetch(url.toString(), {
                 method: "GET",
@@ -79,7 +85,7 @@ const defaultDataProvider: DataProvider = {
                 .then(({ status, body }) => {
                     const json = parseJSON(status, body, reject);
                     if (json.items.length === 0) {
-                        reject(new Error("Not found"));
+                        return reject(new Error("Not found"));
                     }
                     return resolve({ data: json.items[0] });
                 });


### PR DESCRIPTION
* Add `search_query` filter to DatasetGrid & JobGrid components. Use filter value in `getList` method as API endpoint query param. Requires https://github.com/MobileTeleSystems/data-rentgen/pull/81 to be applied.
* Mark all table columns as non-sortable, as API does not support passing custom sorting field
* Replace list of actions above the table with custom one. Currently user may change column order and disable some columns if not need.

Screenshots:
![Снимок экрана_20241017_151824-1](https://github.com/user-attachments/assets/1a841bfc-e14e-49d6-9bf7-24671e2e02d9)
![Снимок экрана_20241017_150843-1](https://github.com/user-attachments/assets/1502cde6-30bc-44b8-be14-bcb022212a8e)

