### PR TITLE
[DOP-20139] Implement RunList & RunShow components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,8 +12,9 @@ import englishMessages from "./i18n/en";
 import { Layout } from "./layout";
 import { mainLightTheme, mainDarkTheme } from "@/themes/main";
 import { Login } from "./components/login";
-import { DatasetGrid, DatasetShow } from "./components/dataset";
-import { JobGrid, JobShow } from "./components/job";
+import { DatasetList, DatasetShow } from "./components/dataset";
+import { JobList, JobShow } from "./components/job";
+import { RunList, RunShow } from "./components/run";
 
 const store = localStorageStore(undefined, "DataRentgen");
 
@@ -39,11 +40,11 @@ const App = () => {
             >
                 <Resource
                     name="datasets"
-                    list={DatasetGrid}
+                    list={DatasetList}
                     show={DatasetShow}
                 />
-                <Resource name="jobs" list={JobGrid} show={JobShow} />
-                <Resource name="runs" />
+                <Resource name="jobs" list={JobList} show={JobShow} />
+                <Resource name="runs" list={RunList} show={RunShow} />
             </Admin>
         </StoreContextProvider>
     );

--- a/src/components/base/DurationField.tsx
+++ b/src/components/base/DurationField.tsx
@@ -1,0 +1,41 @@
+import { ReactElement } from "react";
+import { FieldProps, FunctionField } from "react-admin";
+
+const getDuration = (startTime: Date, endTime: Date): string => {
+    // @ts-ignore
+    const differenceInSeconds = Math.abs(endTime - startTime) / 1000;
+
+    const hours = Math.floor(differenceInSeconds / 60 / 60);
+    const minutes = Math.floor(differenceInSeconds / 60) - hours * 60;
+    const seconds =
+        Math.floor(differenceInSeconds) - hours * 60 * 60 - minutes * 60;
+
+    if (hours) return `${hours}h ${minutes}m ${seconds}s`;
+    if (minutes) return `${minutes}m ${seconds}s`;
+    return `${seconds}s`;
+};
+
+const DurationField = (
+    props: {
+        start_field: string;
+        end_field: string;
+    } & FieldProps,
+): ReactElement => {
+    const { start_field, end_field, ...rest } = props;
+    return (
+        <FunctionField
+            render={(record) => {
+                if (!record[start_field] || !record[end_field]) {
+                    return null;
+                }
+                return getDuration(
+                    new Date(record[start_field]),
+                    new Date(record[end_field]),
+                );
+            }}
+            {...rest}
+        />
+    );
+};
+
+export default DurationField;

--- a/src/components/base/ListActions.tsx
+++ b/src/components/base/ListActions.tsx
@@ -1,0 +1,17 @@
+import { ReactElement } from "react";
+import { SelectColumnsButton, TopToolbar } from "react-admin";
+
+import { Box } from "@mui/material";
+
+const ListActions = ({ children }: { children?: ReactElement }) => {
+    return (
+        <>
+            {children && <Box width="100%">{children}</Box>}
+            <TopToolbar>
+                <SelectColumnsButton />
+            </TopToolbar>
+        </>
+    );
+};
+
+export default ListActions;

--- a/src/components/base/StatusField.tsx
+++ b/src/components/base/StatusField.tsx
@@ -1,0 +1,26 @@
+import { ReactElement } from "react";
+import { ChipField, ChipFieldProps, useRecordContext } from "react-admin";
+
+const StatusField = ({ ...props }: ChipFieldProps): ReactElement | null => {
+    const record = useRecordContext();
+    if (!record) return null;
+
+    switch (record.status) {
+        case "STARTED":
+            return <ChipField color="info" {...props} />;
+        case "RUNNING":
+            return <ChipField color="primary" {...props} />;
+        case "SUCCEEDED":
+            return <ChipField color="success" {...props} />;
+        case "FAILED":
+            return <ChipField color="error" {...props} />;
+        case "KILLED":
+            return <ChipField color="error" {...props} />;
+        case "UNKNOWN":
+            return <ChipField color="warning" {...props} />;
+        default:
+            return <ChipField {...props} />;
+    }
+};
+
+export default StatusField;

--- a/src/components/base/index.ts
+++ b/src/components/base/index.ts
@@ -1,0 +1,5 @@
+import StatusField from "./StatusField";
+import DurationField from "./DurationField";
+import ListActions from "./ListActions";
+
+export { StatusField, DurationField, ListActions };

--- a/src/components/dataset/DatasetList.tsx
+++ b/src/components/dataset/DatasetList.tsx
@@ -3,27 +3,34 @@ import {
     List,
     TextField,
     WrapperField,
-    TopToolbar,
-    SelectColumnsButton,
     DatagridConfigurable,
     SearchInput,
     minLength,
+    useTranslate,
 } from "react-admin";
+import { ListActions } from "@/components/base";
 import DatasetLocationIcon from "./DatasetLocationIcon";
 
-const DatasetGridActions = () => (
-    <TopToolbar>
-        <SelectColumnsButton />
-    </TopToolbar>
-);
+const DatasetList = (): ReactElement => {
+    const translate = useTranslate();
 
-const datasetFilters = [
-    <SearchInput source="search_query" alwaysOn validate={minLength(3)} />,
-];
+    const datasetFilters = [
+        <SearchInput
+            source="search_query"
+            alwaysOn
+            validate={minLength(3)}
+            placeholder={translate(
+                "resources.datasets.filters.search_query.placeholder",
+            )}
+        />,
+    ];
 
-const DatasetGrid = (): ReactElement => {
     return (
-        <List actions={<DatasetGridActions />} filters={datasetFilters}>
+        <List
+            actions={<ListActions />}
+            filters={datasetFilters}
+            resource="datasets"
+        >
             <DatagridConfigurable bulkActionButtons={false}>
                 <WrapperField source="location.type" sortable={false}>
                     <DatasetLocationIcon />
@@ -35,4 +42,4 @@ const DatasetGrid = (): ReactElement => {
     );
 };
 
-export default DatasetGrid;
+export default DatasetList;

--- a/src/components/dataset/DatasetShow.tsx
+++ b/src/components/dataset/DatasetShow.tsx
@@ -10,7 +10,7 @@ import DatasetLocationIcon from "./DatasetLocationIcon";
 
 const DatasetShow = (): ReactElement => {
     return (
-        <Show>
+        <Show resource="datasets">
             <SimpleShowLayout>
                 <TextField source="id" />
                 <WrapperField source="location.type">

--- a/src/components/dataset/index.ts
+++ b/src/components/dataset/index.ts
@@ -1,4 +1,4 @@
 import DatasetShow from "./DatasetShow";
-import DatasetGrid from "./DatasetGrid";
+import DatasetList from "./DatasetList";
 
-export { DatasetShow, DatasetGrid };
+export { DatasetShow, DatasetList };

--- a/src/components/job/JobList.tsx
+++ b/src/components/job/JobList.tsx
@@ -3,28 +3,31 @@ import {
     List,
     TextField,
     WrapperField,
-    TopToolbar,
-    SelectColumnsButton,
     SearchInput,
     minLength,
     DatagridConfigurable,
+    useTranslate,
 } from "react-admin";
+import { ListActions } from "@/components/base";
 import JobIcon from "./JobIcon";
 import JobLocationIcon from "./JobLocationIcon";
 
-const JobGridActions = () => (
-    <TopToolbar>
-        <SelectColumnsButton />
-    </TopToolbar>
-);
+const JobList = (): ReactElement => {
+    const translate = useTranslate();
 
-const jobFilters = [
-    <SearchInput source="search_query" alwaysOn validate={minLength(3)} />,
-];
+    const jobFilters = [
+        <SearchInput
+            source="search_query"
+            alwaysOn
+            validate={minLength(3)}
+            placeholder={translate(
+                "resources.jobs.filters.search_query.placeholder",
+            )}
+        />,
+    ];
 
-const JobGrid = (): ReactElement => {
     return (
-        <List actions={<JobGridActions />} filters={jobFilters}>
+        <List actions={<ListActions />} filters={jobFilters} resource="jobs">
             <DatagridConfigurable bulkActionButtons={false}>
                 <WrapperField source="type" sortable={false}>
                     <JobIcon />
@@ -39,4 +42,4 @@ const JobGrid = (): ReactElement => {
     );
 };
 
-export default JobGrid;
+export default JobList;

--- a/src/components/job/JobShow.tsx
+++ b/src/components/job/JobShow.tsx
@@ -1,11 +1,21 @@
 import { ReactElement } from "react";
-import { Show, SimpleShowLayout, TextField, WrapperField } from "react-admin";
+import {
+    Show,
+    SimpleShowLayout,
+    TabbedShowLayout,
+    TextField,
+    WithRecord,
+    WrapperField,
+} from "react-admin";
+import Divider from "@mui/material/Divider";
+
 import JobIconWithText from "./JobIcon";
 import JobLocationIconWithText from "./JobLocationIcon";
+import { RunListForJob } from "../run";
 
 const JobShow = (): ReactElement => {
     return (
-        <Show>
+        <Show resource="jobs">
             <SimpleShowLayout>
                 <TextField source="id" />
                 <WrapperField source="type">
@@ -16,6 +26,11 @@ const JobShow = (): ReactElement => {
                     <JobLocationIconWithText />
                 </WrapperField>
                 <TextField source="location.name" />
+                <Divider />
+                <WithRecord
+                    label="Runs"
+                    render={(record) => <RunListForJob jobId={record.id} />}
+                />
             </SimpleShowLayout>
         </Show>
     );

--- a/src/components/job/index.ts
+++ b/src/components/job/index.ts
@@ -1,4 +1,4 @@
 import JobShow from "./JobShow";
-import JobGrid from "./JobGrid";
+import JobList from "./JobList";
 
-export { JobShow, JobGrid };
+export { JobShow, JobList };

--- a/src/components/run/RunExternalIdField.tsx
+++ b/src/components/run/RunExternalIdField.tsx
@@ -1,0 +1,23 @@
+import { RunResponseV1 } from "@/dataProvider/types";
+import { Link } from "@mui/material";
+import { FieldProps, TextField, useRecordContext } from "react-admin";
+
+const RunExternalIdField = (props: FieldProps) => {
+    const record = useRecordContext<RunResponseV1>();
+    if (!record || !record.external_id) {
+        return null;
+    }
+
+    const log_url = record.persistent_log_url || record.running_log_url;
+
+    if (!log_url) {
+        return <TextField {...props} />;
+    }
+
+    return (
+        <Link href={log_url} target="_blank">
+            {record.external_id}
+        </Link>
+    );
+};
+export default RunExternalIdField;

--- a/src/components/run/RunList.tsx
+++ b/src/components/run/RunList.tsx
@@ -1,0 +1,52 @@
+import { ReactElement, useState } from "react";
+import {
+    List,
+    DatagridConfigurable,
+    DateField,
+    ReferenceField,
+    WrapperField,
+    TextField,
+} from "react-admin";
+
+import { DurationField, StatusField, ListActions } from "@/components/base";
+import RunExternalIdField from "./RunExternalIdField";
+import RunListFilters from "./RunListFilters";
+
+const RunList = (): ReactElement => {
+    // Hack to avoid sending any network requests until user passed all required filters
+    // See https://github.com/marmelab/react-admin/issues/10286
+    const [enabled, setEnabled] = useState(false);
+
+    return (
+        <List
+            resource="runs"
+            actions={
+                <ListActions>
+                    <RunListFilters
+                        isReadyCallback={setEnabled}
+                        requiredFilters={["since", "search_query"]}
+                    />
+                </ListActions>
+            }
+            queryOptions={{ enabled }}
+        >
+            <DatagridConfigurable bulkActionButtons={false}>
+                <DateField source="created_at" showTime={true} />
+                <ReferenceField source="job_id" reference="jobs" />
+                <StatusField source="status" />
+                <DurationField
+                    source="duration"
+                    start_field="started_at"
+                    end_field="ended_at"
+                />
+                <WrapperField source="started_by_user">
+                    <TextField source="started_by_user.name" />
+                </WrapperField>
+                <RunExternalIdField source="external_id" />
+                <ReferenceField source="parent_run_id" reference="runs" />
+            </DatagridConfigurable>
+        </List>
+    );
+};
+
+export default RunList;

--- a/src/components/run/RunListFilters.tsx
+++ b/src/components/run/RunListFilters.tsx
@@ -1,0 +1,105 @@
+import { required, minLength, DateTimeInput, useTranslate } from "react-admin";
+
+import { useForm, FormProvider } from "react-hook-form";
+import { Box, Button, InputAdornment } from "@mui/material";
+import SearchIcon from "@mui/icons-material/Search";
+import { TextInput, useListContext } from "react-admin";
+
+const weekAgo = (): Date => {
+    const result = new Date();
+    result.setDate(result.getDate() - 7);
+    result.setHours(0, 0, 0, 0);
+    return result;
+};
+
+type RunListFiltersProps = {
+    isReadyCallback: (enabled: boolean) => void;
+    requiredFilters: string[];
+};
+
+const RunListFilters = ({
+    isReadyCallback,
+    requiredFilters = ["since", "search_query"],
+}: RunListFiltersProps) => {
+    const translate = useTranslate();
+    const { filterValues, setFilters } = useListContext();
+    const form = useForm({ defaultValues: filterValues });
+
+    const requiredFieldsFilled = requiredFilters.every(
+        (filter) => !!filterValues[filter],
+    );
+
+    isReadyCallback(requiredFieldsFilled);
+
+    const initialValidators = (field: string) =>
+        requiredFilters.includes(field) ? [required()] : [];
+
+    const onSubmit = (values: {
+        since?: string;
+        until?: string;
+        search_query?: string;
+    }) => {
+        if (Object.keys(values).length > 0) {
+            setFilters(values);
+        }
+    };
+
+    return (
+        <FormProvider {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)}>
+                <Box display="flex" alignItems="flex-end">
+                    <Box component="span" mr={2}>
+                        <DateTimeInput
+                            source="since"
+                            validate={initialValidators("since")}
+                            defaultValue={weekAgo()}
+                            label="resources.runs.filters.since.label"
+                            helperText="resources.runs.filters.since.helperText"
+                        />
+                    </Box>
+
+                    <Box component="span" mr={2}>
+                        <DateTimeInput
+                            source="until"
+                            validate={initialValidators("until")}
+                            label="resources.runs.filters.until.label"
+                            helperText="resources.runs.filters.until.helperText"
+                        />
+                    </Box>
+
+                    <Box component="span" mr={2}>
+                        {/* Not using SearchInput here because it doesn't match styles with other filters */}
+                        <TextInput
+                            source="search_query"
+                            InputProps={{
+                                endAdornment: (
+                                    <InputAdornment position="end">
+                                        <SearchIcon color="disabled" />
+                                    </InputAdornment>
+                                ),
+                            }}
+                            validate={[
+                                minLength(3),
+                                ...initialValidators("search_query"),
+                            ]}
+                            label="resources.runs.filters.search_query.label"
+                            helperText="resources.runs.filters.search_query.helperText"
+                        />
+                    </Box>
+
+                    <Box component="span" mr={2} mb={4}>
+                        <Button
+                            variant="outlined"
+                            color="primary"
+                            type="submit"
+                        >
+                            {translate("resources.runs.filters.search_button")}
+                        </Button>
+                    </Box>
+                </Box>
+            </form>
+        </FormProvider>
+    );
+};
+
+export default RunListFilters;

--- a/src/components/run/RunListForJob.tsx
+++ b/src/components/run/RunListForJob.tsx
@@ -1,0 +1,56 @@
+import { ReactElement, useState } from "react";
+import {
+    List,
+    DatagridConfigurable,
+    DateField,
+    ReferenceField,
+    WrapperField,
+    TextField,
+} from "react-admin";
+
+import { DurationField, StatusField, ListActions } from "@/components/base";
+import RunExternalIdField from "./RunExternalIdField";
+import RunListFilters from "./RunListFilters";
+
+const RunListForJob = ({ jobId }: { jobId: number }): ReactElement => {
+    // Hack to avoid sending any network requests until user passed all required filters
+    // See https://github.com/marmelab/react-admin/issues/10286
+    const [enabled, setEnabled] = useState(false);
+
+    return (
+        <List
+            resource="runs"
+            filter={{ job_id: jobId }}
+            actions={
+                <ListActions>
+                    <RunListFilters
+                        isReadyCallback={setEnabled}
+                        requiredFilters={["since"]}
+                    />
+                </ListActions>
+            }
+            queryOptions={{ enabled }}
+            /* Use distinct filters from RunList component */
+            storeKey="runListForJob"
+            title={false}
+        >
+            <DatagridConfigurable bulkActionButtons={false}>
+                <DateField source="created_at" showTime={true} />
+                {/* Do not show job, as we already in JobShow page*/}
+                <StatusField source="status" />
+                <DurationField
+                    source="duration"
+                    start_field="started_at"
+                    end_field="ended_at"
+                />
+                <WrapperField source="started_by_user">
+                    <TextField source="started_by_user.name" />
+                </WrapperField>
+                <RunExternalIdField source="external_id" />
+                <ReferenceField source="parent_run_id" reference="runs" />
+            </DatagridConfigurable>
+        </List>
+    );
+};
+
+export default RunListForJob;

--- a/src/components/run/RunShow.tsx
+++ b/src/components/run/RunShow.tsx
@@ -1,0 +1,95 @@
+import { Stack } from "@mui/material";
+import { ReactElement } from "react";
+import {
+    DateField,
+    Labeled,
+    ReferenceField,
+    RichTextField,
+    Show,
+    SimpleShowLayout,
+    TextField,
+    UrlField,
+    WrapperField,
+} from "react-admin";
+import { DurationField, StatusField } from "@/components/base";
+
+const RunShow = (): ReactElement => {
+    return (
+        <Show>
+            <SimpleShowLayout>
+                <TextField source="id" />
+
+                <Labeled label="resources.runs.sections.created">
+                    <Stack direction="row" spacing={3}>
+                        <Labeled label="resources.runs.sections.when">
+                            <DateField source="created_at" showTime={true} />
+                        </Labeled>
+                        <Labeled label="resources.runs.sections.for_job">
+                            <ReferenceField source="job_id" reference="jobs" />
+                        </Labeled>
+                        <Labeled label="resources.runs.sections.by_parent_run">
+                            <ReferenceField
+                                source="parent_run_id"
+                                reference="runs"
+                            />
+                        </Labeled>
+                    </Stack>
+                </Labeled>
+
+                <Labeled label="resources.runs.sections.started">
+                    <Stack direction="row" spacing={3}>
+                        <Labeled label="resources.runs.sections.when">
+                            <DateField source="started_at" showTime={true} />
+                        </Labeled>
+                        <Labeled label="resources.runs.sections.how">
+                            <TextField source="start_reason" />
+                        </Labeled>
+                        <Labeled label="resources.runs.sections.as_user">
+                            <WrapperField source="started_by_user">
+                                <TextField source="started_by_user.name" />
+                            </WrapperField>
+                        </Labeled>
+                    </Stack>
+                </Labeled>
+
+                <StatusField source="status" />
+                <Labeled label="resources.runs.sections.ended">
+                    <Stack direction="row" spacing={3}>
+                        <Labeled label="resources.runs.sections.when">
+                            <DateField source="ended_at" showTime={true} />
+                        </Labeled>
+                        <Labeled label="resources.runs.sections.how">
+                            <RichTextField source="end_reason" />
+                        </Labeled>
+                        <Labeled label="resources.runs.sections.duration">
+                            <DurationField
+                                source="duration"
+                                start_field="started_at"
+                                end_field="ended_at"
+                            />
+                        </Labeled>
+                    </Stack>
+                </Labeled>
+
+                <Labeled label="resources.runs.sections.external">
+                    <Stack direction="row" spacing={3}>
+                        <Labeled label="resources.runs.sections.id">
+                            <TextField source="external_id" />
+                        </Labeled>
+                        <Labeled label="resources.runs.sections.attempt">
+                            <TextField source="attempt" />
+                        </Labeled>
+                        <Labeled label="resources.runs.sections.external_url">
+                            <UrlField source="running_log_url" />
+                        </Labeled>
+                        <Labeled label="resources.runs.sections.logs_url">
+                            <UrlField source="persistent_log_url" />
+                        </Labeled>
+                    </Stack>
+                </Labeled>
+            </SimpleShowLayout>
+        </Show>
+    );
+};
+
+export default RunShow;

--- a/src/components/run/index.ts
+++ b/src/components/run/index.ts
@@ -1,0 +1,5 @@
+import RunShow from "./RunShow";
+import RunList from "./RunList";
+import RunListForJob from "./RunListForJob";
+
+export { RunShow, RunList, RunListForJob };

--- a/src/dataProvider/types.ts
+++ b/src/dataProvider/types.ts
@@ -11,10 +11,12 @@ interface LocationResponseV1 {
 }
 
 interface DatasetResponseV1 extends RaRecord {
+    kind: "DATASET";
     id: number;
     type: string;
     name: string;
     location: LocationResponseV1;
+    format: string | null;
 }
 
 type JobTypeResponseV1 =
@@ -24,10 +26,48 @@ type JobTypeResponseV1 =
     | "UNKNOWN";
 
 interface JobResponseV1 extends RaRecord {
+    kind: "JOB";
     id: number;
     type: JobTypeResponseV1;
     name: string;
     location: LocationResponseV1;
 }
 
-export type { LocationResponseV1, DatasetResponseV1, JobResponseV1 };
+interface UserResponseV1 extends RaRecord {
+    name: string;
+}
+
+type StatusResponseV1 =
+    | "STARTED"
+    | "RUNNING"
+    | "SUCCEEDED"
+    | "FAILED"
+    | "KILLED"
+    | "UNKNOWN";
+
+type StartReasonResponseV1 = "AUTOMATIC" | "MANUAL";
+
+interface RunResponseV1 extends RaRecord {
+    kind: "RUN";
+    id: string;
+    created_at: string;
+    job_id: number;
+    status: StatusResponseV1;
+    parent_run_id: string | null;
+    started_at: string | null;
+    started_by_user: UserResponseV1 | null;
+    start_reason: StartReasonResponseV1 | null;
+    ended_at: string | null;
+    end_reason: string | null;
+    external_id: string | null;
+    attempt: string | null;
+    running_log_url: string | null;
+    persistent_log_url: string | null;
+}
+
+export type {
+    LocationResponseV1,
+    DatasetResponseV1,
+    JobResponseV1,
+    RunResponseV1,
+};

--- a/src/dataProvider/utils.ts
+++ b/src/dataProvider/utils.ts
@@ -17,10 +17,12 @@ const parseJSON = (
     try {
         json = JSON.parse(body);
     } catch (e) {
-        reject(e);
+        return reject(e);
     }
     if (status < 200 || status >= 400) {
-        reject(new HttpError((json && json.message) || body, status, json));
+        return reject(
+            new HttpError((json && json.message) || body, status, json),
+        );
     }
     return json;
 };

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -51,6 +51,21 @@ const customEnglishMessages: TranslationMessages = {
             name: "Dataset |||| Datasets",
             amount: "1 dataset |||| %{smart_count} datasets",
             title: "Dataset %{reference}",
+            fields: {
+                id: "Dataset ID",
+                name: "Dataset name",
+                format: "Format",
+                location: {
+                    name: "Location Name",
+                    type: "Location Type",
+                },
+            },
+            filters: {
+                search_query: {
+                    label: "Search",
+                    placeholder: "Filter by name or address",
+                },
+            },
         },
         jobs: {
             name: "Job |||| Jobs",
@@ -65,11 +80,73 @@ const customEnglishMessages: TranslationMessages = {
                     application: "Spark Application",
                 },
             },
+            fields: {
+                id: "Job ID",
+                name: "Job Name",
+                type: "Job Type",
+                location: {
+                    name: "Location Name",
+                    type: "Location Type",
+                },
+            },
+            filters: {
+                search_query: {
+                    label: "Search",
+                    placeholder: "Filter by name or address",
+                },
+            },
         },
         runs: {
             name: "Run |||| Runs",
             amount: "1 run |||| %{smart_count} runs",
             title: "Run %{reference}",
+            fields: {
+                id: "Run ID",
+                created_at: "Created at",
+                job_id: "Job ID",
+                status: "Status",
+                parent_run_id: "Parent Run ID",
+                started_at: "Started at",
+                started_by_user: "Started by user",
+                start_reason: "Start reason",
+                ended_at: "Ended at",
+                end_reason: "End reason",
+                external_id: "External ID",
+                attempt: "Attempt",
+                running_log_url: "Running log URL",
+                persistent_log_url: "Persistent log URL",
+            },
+            sections: {
+                created: "Created",
+                started: "Started",
+                ended: "Ended",
+                external: "External",
+                when: "When",
+                how: "How",
+                for_job: "For Job",
+                by_parent_run: "By Parent Run",
+                as_user: "As User",
+                duration: "Duration",
+                id: "ID",
+                attempt: "Attempt",
+                external_url: "External URL",
+                logs_url: "Logs URL",
+            },
+            filters: {
+                since: {
+                    label: "Since",
+                    helperText: "Include only runs created after",
+                },
+                until: {
+                    label: "Until",
+                    helperText: "Include only runs created before",
+                },
+                search_query: {
+                    label: "Search",
+                    helperText: "Filter by applicationId",
+                },
+                search_button: "Search",
+            },
         },
     },
     errors: {


### PR DESCRIPTION
* Renamed DatasetGrid & JobGrid to DatasetList & JobList.
* Implemented RunShow component.
![Снимок экрана_20241022_130650](https://github.com/user-attachments/assets/76de2eff-f987-413a-83c2-c78d9aea46d3)
![Снимок экрана_20241022_130445](https://github.com/user-attachments/assets/66710ed0-42c9-46ab-a2f8-027160af9ade)

* Implemented RunList component, It has 2 required filters `since` and `search_query`, and one optional filter `until`.
![Снимок экрана_20241022_130432](https://github.com/user-attachments/assets/bc7476d1-e9c7-430f-af09-1ba20ad35139)

  Filter implementation is a bit different from DatasetList & JobList, as react-admin currently does not support filters with `required()` validator. I've implemented filters using a custom form, like recommended here: https://github.com/marmelab/react-admin/issues/10286.

* Implemented RunListForJob component. It's a copy of RunList, but with permanent filter by `jobId`, and with optional `search_query` filter. This component is embedded into the `JobShow` page.
![Снимок экрана_20241022_130422](https://github.com/user-attachments/assets/81740b5a-e324-4ee5-8203-ae42a70ed45b)
