### PR TITLE
[DOP-20144] Implement OperationListForRun & OperationShow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { Login } from "./components/login";
 import { DatasetList, DatasetShow } from "./components/dataset";
 import { JobList, JobShow } from "./components/job";
 import { RunList, RunShow } from "./components/run";
+import { OperationShow } from "./components/operation";
 
 const store = localStorageStore(undefined, "DataRentgen");
 
@@ -45,6 +46,7 @@ const App = () => {
                 />
                 <Resource name="jobs" list={JobList} show={JobShow} />
                 <Resource name="runs" list={RunList} show={RunShow} />
+                <Resource name="operations" show={OperationShow} />
             </Admin>
         </StoreContextProvider>
     );

--- a/src/components/job/JobShow.tsx
+++ b/src/components/job/JobShow.tsx
@@ -2,8 +2,8 @@ import { ReactElement } from "react";
 import {
     Show,
     SimpleShowLayout,
-    TabbedShowLayout,
     TextField,
+    useTranslate,
     WithRecord,
     WrapperField,
 } from "react-admin";
@@ -14,6 +14,7 @@ import JobLocationIconWithText from "./JobLocationIcon";
 import { RunListForJob } from "../run";
 
 const JobShow = (): ReactElement => {
+    const translate = useTranslate();
     return (
         <Show resource="jobs">
             <SimpleShowLayout>
@@ -26,9 +27,10 @@ const JobShow = (): ReactElement => {
                     <JobLocationIconWithText />
                 </WrapperField>
                 <TextField source="location.name" />
-                <Divider />
+
+                <Divider>{translate("resources.jobs.sections.runs")}</Divider>
+
                 <WithRecord
-                    label="Runs"
                     render={(record) => <RunListForJob jobId={record.id} />}
                 />
             </SimpleShowLayout>

--- a/src/components/operation/OperationListFilters.tsx
+++ b/src/components/operation/OperationListFilters.tsx
@@ -1,0 +1,56 @@
+import { required, DateTimeInput, useTranslate } from "react-admin";
+
+import { useForm, FormProvider } from "react-hook-form";
+import { Box, Button } from "@mui/material";
+import { useListContext } from "react-admin";
+
+const OperationListFilters = () => {
+    const translate = useTranslate();
+    const { filterValues, setFilters } = useListContext();
+    const form = useForm({ defaultValues: filterValues });
+
+    const onSubmit = (values: { since?: string; until?: string }) => {
+        if (Object.keys(values).length > 0) {
+            setFilters(values);
+        }
+    };
+
+    return (
+        <FormProvider {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)}>
+                <Box display="flex" alignItems="flex-end">
+                    <Box component="span" mr={2}>
+                        <DateTimeInput
+                            source="since"
+                            validate={required()}
+                            label="resources.operations.filters.since.label"
+                            helperText="resources.operations.filters.since.helperText"
+                        />
+                    </Box>
+
+                    <Box component="span" mr={2}>
+                        <DateTimeInput
+                            source="until"
+                            label="resources.operations.filters.until.label"
+                            helperText="resources.operations.filters.until.helperText"
+                        />
+                    </Box>
+
+                    <Box component="span" mr={2} mb={4}>
+                        <Button
+                            variant="outlined"
+                            color="primary"
+                            type="submit"
+                        >
+                            {translate(
+                                "resources.operations.filters.apply_button",
+                            )}
+                        </Button>
+                    </Box>
+                </Box>
+            </form>
+        </FormProvider>
+    );
+};
+
+export default OperationListFilters;

--- a/src/components/operation/OperationListForRun.tsx
+++ b/src/components/operation/OperationListForRun.tsx
@@ -1,0 +1,54 @@
+import { ReactElement } from "react";
+import {
+    List,
+    DatagridConfigurable,
+    DateField,
+    WrapperField,
+    TextField,
+    FunctionField,
+} from "react-admin";
+
+import { Stack } from "@mui/material";
+
+import { DurationField, StatusField, ListActions } from "@/components/base";
+import { RunResponseV1 } from "@/dataProvider/types";
+import OperationListFilters from "./OperationListFilters";
+
+const OperationListForRun = ({ run }: { run: RunResponseV1 }): ReactElement => {
+    return (
+        <List
+            resource="operations"
+            filter={{ run_id: run.id }}
+            filterDefaultValues={{ since: run.created_at }}
+            actions={
+                <ListActions>
+                    <OperationListFilters />
+                </ListActions>
+            }
+            title={false}
+            /* Reset filters on every RunShow page */
+            disableSyncWithLocation
+        >
+            <DatagridConfigurable bulkActionButtons={false}>
+                <DateField source="created_at" showTime={true} />
+                {/* Do not show run, as we already in RunShow page*/}
+                <TextField source="position" sortable={false} />
+                <TextField source="group" sortable={false} />
+                <FunctionField
+                    source="description"
+                    render={(record) => record.description || record.name}
+                    sortable={false}
+                />
+                <StatusField source="status" sortable={false} />
+                <DurationField
+                    source="duration"
+                    start_field="started_at"
+                    end_field="ended_at"
+                    sortable={false}
+                />
+            </DatagridConfigurable>
+        </List>
+    );
+};
+
+export default OperationListForRun;

--- a/src/components/operation/OperationShow.tsx
+++ b/src/components/operation/OperationShow.tsx
@@ -1,0 +1,67 @@
+import { Stack } from "@mui/material";
+import { ReactElement } from "react";
+import {
+    DateField,
+    Labeled,
+    ReferenceField,
+    Show,
+    SimpleShowLayout,
+    TextField,
+} from "react-admin";
+import { DurationField, StatusField } from "@/components/base";
+
+const OperationShow = (): ReactElement => {
+    return (
+        <Show>
+            <SimpleShowLayout>
+                <TextField source="id" />
+                <TextField source="name" />
+
+                <Labeled label="resources.operations.sections.external">
+                    <Stack direction="row" spacing={3}>
+                        <Labeled label="resources.operations.sections.position">
+                            <TextField source="position" />
+                        </Labeled>
+                        <Labeled label="resources.operations.sections.group">
+                            <TextField source="group" />
+                        </Labeled>
+                        <Labeled label="resources.operations.sections.description">
+                            <TextField source="description" />
+                        </Labeled>
+                    </Stack>
+                </Labeled>
+
+                <Labeled label="resources.operations.sections.created">
+                    <Stack direction="row" spacing={3}>
+                        <Labeled label="resources.operations.sections.when">
+                            <DateField source="created_at" showTime={true} />
+                        </Labeled>
+                        <Labeled label="resources.operations.sections.by_run">
+                            <ReferenceField source="run_id" reference="runs" />
+                        </Labeled>
+                    </Stack>
+                </Labeled>
+
+                <DateField source="started_at" showTime={true} />
+
+                <StatusField source="status" />
+                <Labeled label="resources.operations.sections.ended">
+                    <Stack direction="row" spacing={3}>
+                        <Labeled label="resources.operations.sections.when">
+                            <DateField source="ended_at" showTime={true} />
+                        </Labeled>
+                        <Labeled label="resources.operations.sections.duration">
+                            <DurationField
+                                source="duration"
+                                start_field="started_at"
+                                end_field="ended_at"
+                            />
+                        </Labeled>
+                    </Stack>
+                </Labeled>
+            </SimpleShowLayout>
+        </Show>
+    );
+};
+
+export default OperationShow;

--- a/src/components/operation/index.ts
+++ b/src/components/operation/index.ts
@@ -1,0 +1,4 @@
+import OperationShow from "./OperationShow";
+import OperationListForRun from "./OperationListForRun";
+
+export { OperationShow, OperationListForRun };

--- a/src/components/run/RunList.tsx
+++ b/src/components/run/RunList.tsx
@@ -31,19 +31,32 @@ const RunList = (): ReactElement => {
             queryOptions={{ enabled }}
         >
             <DatagridConfigurable bulkActionButtons={false}>
-                <DateField source="created_at" showTime={true} />
-                <ReferenceField source="job_id" reference="jobs" />
-                <StatusField source="status" />
+                <DateField
+                    source="created_at"
+                    showTime={true}
+                    sortable={false}
+                />
+                <ReferenceField
+                    source="job_id"
+                    reference="jobs"
+                    sortable={false}
+                />
+                <StatusField source="status" sortable={false} />
                 <DurationField
                     source="duration"
                     start_field="started_at"
                     end_field="ended_at"
+                    sortable={false}
                 />
-                <WrapperField source="started_by_user">
+                <WrapperField source="started_by_user" sortable={false}>
                     <TextField source="started_by_user.name" />
                 </WrapperField>
-                <RunExternalIdField source="external_id" />
-                <ReferenceField source="parent_run_id" reference="runs" />
+                <RunExternalIdField source="external_id" sortable={false} />
+                <ReferenceField
+                    source="parent_run_id"
+                    reference="runs"
+                    sortable={false}
+                />
             </DatagridConfigurable>
         </List>
     );

--- a/src/components/run/RunListFilters.tsx
+++ b/src/components/run/RunListFilters.tsx
@@ -93,7 +93,7 @@ const RunListFilters = ({
                             color="primary"
                             type="submit"
                         >
-                            {translate("resources.runs.filters.search_button")}
+                            {translate("resources.runs.filters.apply_button")}
                         </Button>
                     </Box>
                 </Box>

--- a/src/components/run/RunListForJob.tsx
+++ b/src/components/run/RunListForJob.tsx
@@ -35,19 +35,28 @@ const RunListForJob = ({ jobId }: { jobId: number }): ReactElement => {
             title={false}
         >
             <DatagridConfigurable bulkActionButtons={false}>
-                <DateField source="created_at" showTime={true} />
+                <DateField
+                    source="created_at"
+                    showTime={true}
+                    sortable={false}
+                />
                 {/* Do not show job, as we already in JobShow page*/}
-                <StatusField source="status" />
+                <StatusField source="status" sortable={false} />
                 <DurationField
                     source="duration"
                     start_field="started_at"
                     end_field="ended_at"
+                    sortable={false}
                 />
-                <WrapperField source="started_by_user">
+                <WrapperField source="started_by_user" sortable={false}>
                     <TextField source="started_by_user.name" />
                 </WrapperField>
-                <RunExternalIdField source="external_id" />
-                <ReferenceField source="parent_run_id" reference="runs" />
+                <RunExternalIdField source="external_id" sortable={false} />
+                <ReferenceField
+                    source="parent_run_id"
+                    reference="runs"
+                    sortable={false}
+                />
             </DatagridConfigurable>
         </List>
     );

--- a/src/components/run/RunShow.tsx
+++ b/src/components/run/RunShow.tsx
@@ -1,4 +1,4 @@
-import { Stack } from "@mui/material";
+import { Divider, Stack } from "@mui/material";
 import { ReactElement } from "react";
 import {
     DateField,
@@ -9,11 +9,16 @@ import {
     SimpleShowLayout,
     TextField,
     UrlField,
+    useTranslate,
+    WithRecord,
     WrapperField,
 } from "react-admin";
 import { DurationField, StatusField } from "@/components/base";
+import { OperationListForRun } from "../operation";
 
 const RunShow = (): ReactElement => {
+    const translate = useTranslate();
+
     return (
         <Show>
             <SimpleShowLayout>
@@ -87,6 +92,14 @@ const RunShow = (): ReactElement => {
                         </Labeled>
                     </Stack>
                 </Labeled>
+
+                <Divider>
+                    {translate("resources.runs.sections.operations")}
+                </Divider>
+
+                <WithRecord
+                    render={(record) => <OperationListForRun run={record} />}
+                />
             </SimpleShowLayout>
         </Show>
     );

--- a/src/dataProvider/types.ts
+++ b/src/dataProvider/types.ts
@@ -65,9 +65,27 @@ interface RunResponseV1 extends RaRecord {
     persistent_log_url: string | null;
 }
 
+type OperationTypeResponseV1 = "BATCH" | "STREAMING";
+
+interface OperationResponseV1 extends RaRecord {
+    kind: "OPERATION";
+    id: string;
+    created_at: string;
+    run_id: string;
+    type: OperationTypeResponseV1;
+    name: string;
+    position: string | null;
+    group: string | null;
+    description: string | null;
+    status: StatusResponseV1;
+    started_at: string | null;
+    ended_at: string | null;
+}
+
 export type {
     LocationResponseV1,
     DatasetResponseV1,
     JobResponseV1,
     RunResponseV1,
+    OperationResponseV1,
 };

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -89,6 +89,9 @@ const customEnglishMessages: TranslationMessages = {
                     type: "Location Type",
                 },
             },
+            sections: {
+                runs: "Runs",
+            },
             filters: {
                 search_query: {
                     label: "Search",
@@ -131,6 +134,7 @@ const customEnglishMessages: TranslationMessages = {
                 attempt: "Attempt",
                 external_url: "External URL",
                 logs_url: "Logs URL",
+                operations: "Operations",
             },
             filters: {
                 since: {
@@ -145,7 +149,49 @@ const customEnglishMessages: TranslationMessages = {
                     label: "Search",
                     helperText: "Filter by applicationId",
                 },
-                search_button: "Search",
+                apply_button: "Apply",
+            },
+        },
+        operations: {
+            name: "Operation |||| Operations",
+            amount: "1 operation |||| %{smart_count} operations",
+            title: "Operation %{reference}",
+            fields: {
+                id: "Operation ID",
+                created_at: "Created at",
+                run_id: "Run ID",
+                position: "Position",
+                name: "Name",
+                group: "Group",
+                description: "Description",
+                origin: "Origin",
+                status: "Status",
+                started_at: "Started at",
+                ended_at: "Ended at",
+            },
+            sections: {
+                created: "Created",
+                by_run: "By Run",
+                external: "External",
+                name: "Name",
+                position: "Position",
+                group: "Group",
+                description: "Description",
+                started: "Started",
+                ended: "Ended",
+                when: "When",
+                duration: "Duration",
+            },
+            filters: {
+                since: {
+                    label: "Since",
+                    helperText: "Include only operations created after",
+                },
+                until: {
+                    label: "Until",
+                    helperText: "Include only operations created before",
+                },
+                apply_button: "Apply",
             },
         },
     },


### PR DESCRIPTION
* Implemented `OperationListForRun` component. Added it to `RunShow` component, to render list of run's operations:
![Снимок экрана_20241023_173238](https://github.com/user-attachments/assets/d5d19271-69f2-4f41-91b6-cf9cbbfed9f1)

* Implemented `OperationShow` component
* Added `sortable=false` to `RunList*` components, to disallow react-admin to set custom sorting fields (API currently does not support that).
* Small fixes in `JobShow` component - fixed missing translations for `Runs` label, added `Divider`
![Снимок экрана_20241023_173250-1](https://github.com/user-attachments/assets/0a0a1a58-ef8b-4d03-a9ee-a4e35a63e669)
