### PR TITLE
[DOP-20148] Introduce lineage graph components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,10 @@
             "name": "data-rentgen",
             "version": "0.0.1",
             "dependencies": {
+                "@dagrejs/dagre": "^1.1.4",
                 "@mui/icons-material": "^5.16.7",
                 "@mui/material": "^5.16.7",
+                "@xyflow/react": "^12.3.2",
                 "clsx": "^2.1.1",
                 "date-fns": "^3.6.0",
                 "inflection": "^3.0.0",
@@ -405,6 +407,24 @@
             },
             "engines": {
                 "node": ">=6.9.0"
+            }
+        },
+        "node_modules/@dagrejs/dagre": {
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/@dagrejs/dagre/-/dagre-1.1.4.tgz",
+            "integrity": "sha512-QUTc54Cg/wvmlEUxB+uvoPVKFazM1H18kVHBQNmK2NbrDR5ihOCR6CXLnDSZzMcSQKJtabPUWridBOlJM3WkDg==",
+            "license": "MIT",
+            "dependencies": {
+                "@dagrejs/graphlib": "2.2.4"
+            }
+        },
+        "node_modules/@dagrejs/graphlib": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/@dagrejs/graphlib/-/graphlib-2.2.4.tgz",
+            "integrity": "sha512-mepCf/e9+SKYy1d02/UkvSy6+6MoyXhVxP8lLDfA7BPE1X1d4dR0sZznmbM8/XVJ1GPM+Svnx7Xj6ZweByWUkw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">17.0.0"
             }
         },
         "node_modules/@emotion/babel-plugin": {
@@ -1428,6 +1448,55 @@
                 "@babel/types": "^7.20.7"
             }
         },
+        "node_modules/@types/d3-color": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+            "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-drag": {
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+            "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-selection": "*"
+            }
+        },
+        "node_modules/@types/d3-interpolate": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+            "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-color": "*"
+            }
+        },
+        "node_modules/@types/d3-selection": {
+            "version": "3.0.11",
+            "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+            "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+            "license": "MIT"
+        },
+        "node_modules/@types/d3-transition": {
+            "version": "3.0.9",
+            "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+            "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-selection": "*"
+            }
+        },
+        "node_modules/@types/d3-zoom": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+            "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-interpolate": "*",
+                "@types/d3-selection": "*"
+            }
+        },
         "node_modules/@types/estree": {
             "version": "1.0.6",
             "dev": true,
@@ -1753,6 +1822,36 @@
             },
             "peerDependencies": {
                 "vite": "^4.2.0 || ^5.0.0"
+            }
+        },
+        "node_modules/@xyflow/react": {
+            "version": "12.3.4",
+            "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.3.4.tgz",
+            "integrity": "sha512-KjFkj84S+wK8aJF/PORxSkOAeotTTPz++hus+Y95NFMIJGVyl8jjVaaz5B1zyV0prk6ZkbMp6q0vqMjJdZT25Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@xyflow/system": "0.0.45",
+                "classcat": "^5.0.3",
+                "zustand": "^4.4.0"
+            },
+            "peerDependencies": {
+                "react": ">=17",
+                "react-dom": ">=17"
+            }
+        },
+        "node_modules/@xyflow/system": {
+            "version": "0.0.45",
+            "resolved": "https://registry.npmjs.org/@xyflow/system/-/system-0.0.45.tgz",
+            "integrity": "sha512-szP1LjDD4jlRYYhxvgZqOCTMToUVNqjQkrlhb0fhv1sXomU1+yMDdhpQT+FjE4d+rKx08fS10sOuZUl2ycXaDw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/d3-drag": "^3.0.7",
+                "@types/d3-selection": "^3.0.10",
+                "@types/d3-transition": "^3.0.8",
+                "@types/d3-zoom": "^3.0.8",
+                "d3-drag": "^3.0.0",
+                "d3-selection": "^3.0.0",
+                "d3-zoom": "^3.0.0"
             }
         },
         "node_modules/acorn": {
@@ -2219,6 +2318,12 @@
                 "node": ">=8"
             }
         },
+        "node_modules/classcat": {
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+            "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+            "license": "MIT"
+        },
         "node_modules/clean-css": {
             "version": "5.3.3",
             "dev": true,
@@ -2567,6 +2672,111 @@
         "node_modules/csstype": {
             "version": "3.1.3",
             "license": "MIT"
+        },
+        "node_modules/d3-color": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+            "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-dispatch": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+            "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-drag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+            "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-dispatch": "1 - 3",
+                "d3-selection": "3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-ease": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+            "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+            "license": "BSD-3-Clause",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-interpolate": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+            "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-color": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-selection": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+            "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-timer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+            "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/d3-transition": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+            "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-color": "1 - 3",
+                "d3-dispatch": "1 - 3",
+                "d3-ease": "1 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-timer": "1 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "peerDependencies": {
+                "d3-selection": "2 - 3"
+            }
+        },
+        "node_modules/d3-zoom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+            "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+            "license": "ISC",
+            "dependencies": {
+                "d3-dispatch": "1 - 3",
+                "d3-drag": "2 - 3",
+                "d3-interpolate": "1 - 3",
+                "d3-selection": "2 - 3",
+                "d3-transition": "2 - 3"
+            },
+            "engines": {
+                "node": ">=12"
+            }
         },
         "node_modules/data-view-buffer": {
             "version": "1.0.1",
@@ -7075,6 +7285,15 @@
                 "punycode": "^2.1.0"
             }
         },
+        "node_modules/use-sync-external-store": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+            "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+            "license": "MIT",
+            "peerDependencies": {
+                "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+            }
+        },
         "node_modules/v8-compile-cache": {
             "version": "2.4.0",
             "dev": true,
@@ -7409,6 +7628,34 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/zustand": {
+            "version": "4.5.5",
+            "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.5.tgz",
+            "integrity": "sha512-+0PALYNJNgK6hldkgDq2vLrw5f6g/jCInz52n9RTpropGgeAf/ioFUCdtsjCqu4gNhW9D01rUQBROoRjdzyn2Q==",
+            "license": "MIT",
+            "dependencies": {
+                "use-sync-external-store": "1.2.2"
+            },
+            "engines": {
+                "node": ">=12.7.0"
+            },
+            "peerDependencies": {
+                "@types/react": ">=16.8",
+                "immer": ">=9.0.6",
+                "react": ">=16.8"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "immer": {
+                    "optional": true
+                },
+                "react": {
+                    "optional": true
+                }
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
     "private": true,
     "type": "module",
     "dependencies": {
+        "@dagrejs/dagre": "^1.1.4",
         "@mui/icons-material": "^5.16.7",
         "@mui/material": "^5.16.7",
+        "@xyflow/react": "^12.3.2",
         "clsx": "^2.1.1",
         "date-fns": "^3.6.0",
         "inflection": "^3.0.0",

--- a/src/components/base/DurationField.tsx
+++ b/src/components/base/DurationField.tsx
@@ -1,39 +1,19 @@
 import { ReactElement } from "react";
 import { FieldProps, FunctionField } from "react-admin";
 
-const getDuration = (startTime: Date, endTime: Date): string => {
-    // @ts-ignore
-    const differenceInSeconds = Math.abs(endTime - startTime) / 1000;
+import { getDurationText } from "@/utils/datetime";
 
-    const hours = Math.floor(differenceInSeconds / 60 / 60);
-    const minutes = Math.floor(differenceInSeconds / 60) - hours * 60;
-    const seconds =
-        Math.floor(differenceInSeconds) - hours * 60 * 60 - minutes * 60;
-
-    if (hours) return `${hours}h ${minutes}m ${seconds}s`;
-    if (minutes) return `${minutes}m ${seconds}s`;
-    return `${seconds}s`;
-};
-
-const DurationField = (
-    props: {
-        start_field: string;
-        end_field: string;
-    } & FieldProps,
-): ReactElement => {
-    const { start_field, end_field, ...rest } = props;
+const DurationField = (props: FieldProps): ReactElement => {
     return (
         <FunctionField
             render={(record) => {
-                if (!record[start_field] || !record[end_field]) {
-                    return null;
-                }
-                return getDuration(
-                    new Date(record[start_field]),
-                    new Date(record[end_field]),
-                );
+                return getDurationText({
+                    created_at: record.created_at,
+                    started_at: record.started_at,
+                    ended_at: record.ended_at,
+                });
             }}
-            {...rest}
+            {...props}
         />
     );
 };

--- a/src/components/dataset/DatasetRaLineage.tsx
+++ b/src/components/dataset/DatasetRaLineage.tsx
@@ -1,0 +1,22 @@
+import { LineageView } from "@/components/lineage";
+import { ReactFlowProvider } from "@xyflow/react";
+import { useRecordContext } from "react-admin";
+
+const DatasetRaLineage = () => {
+    const record = useRecordContext();
+    if (!record) {
+        return null;
+    }
+    return (
+        <ReactFlowProvider>
+            <LineageView
+                resource="datasets"
+                recordId={record.id}
+                granularities={["JOB", "RUN", "OPERATION"]}
+                defaultDirection="UPSTREAM"
+            />
+        </ReactFlowProvider>
+    );
+};
+
+export default DatasetRaLineage;

--- a/src/components/dataset/DatasetRaShow.tsx
+++ b/src/components/dataset/DatasetRaShow.tsx
@@ -3,10 +3,12 @@ import {
     Show,
     SimpleShowLayout,
     TextField,
+    TabbedShowLayout,
     WithRecord,
     WrapperField,
 } from "react-admin";
 import { LocationIconWithType } from "@/components/location";
+import DatasetRaLineage from "./DatasetRaLineage";
 
 const DatasetShow = (): ReactElement => {
     return (
@@ -27,6 +29,12 @@ const DatasetShow = (): ReactElement => {
                         record.format && <TextField source="format" />
                     }
                 />
+
+                <TabbedShowLayout>
+                    <TabbedShowLayout.Tab label="resources.datasets.tabs.lineage">
+                        <DatasetRaLineage />
+                    </TabbedShowLayout.Tab>
+                </TabbedShowLayout>
             </SimpleShowLayout>
         </Show>
     );

--- a/src/components/job/JobRaLineage.tsx
+++ b/src/components/job/JobRaLineage.tsx
@@ -1,0 +1,22 @@
+import { LineageView } from "@/components/lineage";
+import { ReactFlowProvider } from "@xyflow/react";
+import { useRecordContext } from "react-admin";
+
+const JobRaLineage = () => {
+    const record = useRecordContext();
+    if (!record) {
+        return null;
+    }
+
+    return (
+        <ReactFlowProvider>
+            <LineageView
+                resource="jobs"
+                recordId={record.id}
+                granularities={["JOB", "RUN"]}
+            />
+        </ReactFlowProvider>
+    );
+};
+
+export default JobRaLineage;

--- a/src/components/job/JobRaShow.tsx
+++ b/src/components/job/JobRaShow.tsx
@@ -2,19 +2,18 @@ import { ReactElement } from "react";
 import {
     Show,
     SimpleShowLayout,
+    TabbedShowLayout,
     TextField,
-    useTranslate,
     WithRecord,
     WrapperField,
 } from "react-admin";
-import { Divider } from "@mui/material";
 
 import JobIconWithType from "./JobIconWithType";
+import JobLineage from "./JobRaLineage";
 import { RunRaListForJob } from "@/components/run";
 import { LocationIconWithType } from "@/components/location";
 
 const JobRaShow = (): ReactElement => {
-    const translate = useTranslate();
     return (
         <Show resource="jobs">
             <SimpleShowLayout>
@@ -35,11 +34,22 @@ const JobRaShow = (): ReactElement => {
                 </WrapperField>
                 <TextField source="location.name" />
 
-                <Divider>{translate("resources.jobs.sections.runs")}</Divider>
+                <TabbedShowLayout>
+                    <TabbedShowLayout.Tab label="resources.jobs.tabs.runs">
+                        <WithRecord
+                            render={(record) => (
+                                <RunRaListForJob jobId={record.id} />
+                            )}
+                        />
+                    </TabbedShowLayout.Tab>
 
-                <WithRecord
-                    render={(record) => <RunRaListForJob jobId={record.id} />}
-                />
+                    <TabbedShowLayout.Tab
+                        label="resources.jobs.tabs.lineage"
+                        path="lineage"
+                    >
+                        <JobLineage />
+                    </TabbedShowLayout.Tab>
+                </TabbedShowLayout>
             </SimpleShowLayout>
         </Show>
     );

--- a/src/components/lineage/LineageFilters.tsx
+++ b/src/components/lineage/LineageFilters.tsx
@@ -1,0 +1,158 @@
+import {
+    required,
+    DateTimeInput,
+    useTranslate,
+    SelectInput,
+} from "react-admin";
+
+import { useForm, FormProvider } from "react-hook-form";
+import { Box, Button } from "@mui/material";
+
+const weekAgo = (): Date => {
+    const result = new Date();
+    result.setDate(result.getDate() - 7);
+    result.setHours(0, 0, 0, 0);
+    return result;
+};
+
+type LineageFiltersProps = {
+    onSubmit: (values: {
+        since?: string;
+        until?: string;
+        depth?: number;
+        direction?: string;
+        granularity?: string;
+    }) => void;
+    defaultSince?: Date;
+    defaultDirection?: string;
+    granularities?: string[];
+};
+
+const LineageFilters = ({
+    onSubmit,
+    defaultSince,
+    defaultDirection,
+    granularities = [],
+}: LineageFiltersProps) => {
+    const translate = useTranslate();
+    const form = useForm();
+
+    const granularityChoises = [
+        {
+            id: "JOB",
+            name: "lineage.filters.granularity.job",
+        },
+        {
+            id: "RUN",
+            name: "lineage.filters.granularity.run",
+        },
+        {
+            id: "OPERATION",
+            name: "lineage.filters.granularity.operation",
+        },
+    ];
+
+    const defaultGranularity = granularities[0] ?? null;
+    const granularitiesFiltered = granularityChoises.filter((choise) =>
+        granularities.includes(choise.id),
+    );
+
+    return (
+        <FormProvider {...form}>
+            <form onSubmit={form.handleSubmit(onSubmit)}>
+                <Box display="flex" alignItems="flex-end">
+                    <Box component="span" mr={2}>
+                        <DateTimeInput
+                            source="since"
+                            validate={required()}
+                            defaultValue={defaultSince ?? weekAgo()}
+                            label="lineage.filters.since.label"
+                            helperText="lineage.filters.since.helperText"
+                        />
+                    </Box>
+
+                    <Box component="span" mr={2}>
+                        <DateTimeInput
+                            source="until"
+                            label="lineage.filters.until.label"
+                            helperText="lineage.filters.until.helperText"
+                        />
+                    </Box>
+
+                    <Box component="span" mr={2}>
+                        <SelectInput
+                            source="depth"
+                            choices={[
+                                {
+                                    id: 1,
+                                    name: "1",
+                                },
+                                {
+                                    id: 2,
+                                    name: "2",
+                                },
+                                {
+                                    id: 3,
+                                    name: "3",
+                                },
+                            ]}
+                            defaultValue={1}
+                            validate={required()}
+                            label="lineage.filters.depth.label"
+                            helperText="lineage.filters.depth.helperText"
+                        />
+                    </Box>
+
+                    <Box component="span" mr={2}>
+                        <SelectInput
+                            source="direction"
+                            choices={[
+                                {
+                                    id: "BOTH",
+                                    name: "lineage.filters.direction.both",
+                                },
+                                {
+                                    id: "DOWNSTREAM",
+                                    name: "lineage.filters.direction.downstream",
+                                },
+                                {
+                                    id: "UPSTREAM",
+                                    name: "lineage.filters.direction.upstream",
+                                },
+                            ]}
+                            defaultValue={defaultDirection ?? "BOTH"}
+                            validate={required()}
+                            label="lineage.filters.direction.label"
+                            helperText="lineage.filters.direction.helperText"
+                        />
+                    </Box>
+
+                    {granularitiesFiltered.length > 0 && (
+                        <Box component="span" mr={2}>
+                            <SelectInput
+                                source="granularity"
+                                choices={granularitiesFiltered}
+                                defaultValue={defaultGranularity}
+                                validate={required()}
+                                label="lineage.filters.granularity.label"
+                                helperText="lineage.filters.granularity.helperText"
+                            />
+                        </Box>
+                    )}
+
+                    <Box component="span" mr={2} mb={4}>
+                        <Button
+                            variant="outlined"
+                            color="primary"
+                            type="submit"
+                        >
+                            {translate("lineage.build_button")}
+                        </Button>
+                    </Box>
+                </Box>
+            </form>
+        </FormProvider>
+    );
+};
+
+export default LineageFilters;

--- a/src/components/lineage/LineageGraph.tsx
+++ b/src/components/lineage/LineageGraph.tsx
@@ -1,0 +1,58 @@
+import {
+    MiniMap,
+    Controls,
+    Background,
+    ReactFlow,
+    ReactFlowProps,
+    useReactFlow,
+    useNodesInitialized,
+    BackgroundVariant,
+} from "@xyflow/react";
+import { DatasetNode, JobNode, RunNode, OperationNode } from "./nodes";
+import { useEffect } from "react";
+
+export const MIN_ZOOM_VALUE = 0.1;
+export const MAX_ZOOM_VALUE = 2.5;
+
+const nodeTypes = {
+    datasetNode: DatasetNode,
+    jobNode: JobNode,
+    runNode: RunNode,
+    operationNode: OperationNode,
+};
+
+const LineageGraph = (props: ReactFlowProps) => {
+    const { fitView } = useReactFlow();
+
+    const nodesInitialized = useNodesInitialized();
+
+    useEffect(() => {
+        fitView();
+    }, [nodesInitialized]);
+
+    return (
+        <ReactFlow
+            nodeTypes={nodeTypes}
+            nodesFocusable={true}
+            elementsSelectable={true}
+            nodesConnectable={false}
+            nodesDraggable={true}
+            panOnScroll={false}
+            panOnDrag={true}
+            minZoom={MIN_ZOOM_VALUE}
+            maxZoom={MAX_ZOOM_VALUE}
+            zoomOnScroll={true}
+            zoomOnPinch={true}
+            zoomOnDoubleClick={false}
+            fitView
+            onDoubleClick={() => fitView()}
+            {...props}
+        >
+            <Background variant={BackgroundVariant.Dots} />
+            <Controls />
+            <MiniMap pannable zoomable />
+        </ReactFlow>
+    );
+};
+
+export default LineageGraph;

--- a/src/components/lineage/LineageView.tsx
+++ b/src/components/lineage/LineageView.tsx
@@ -1,0 +1,78 @@
+import { useDataProvider, useNotify } from "react-admin";
+
+import buildLineageLayout from "./utils/buildLayout";
+import { Edge, Node, useNodesState, useEdgesState } from "@xyflow/react";
+import LineageFilters from "./LineageFilters";
+import LineageGraph from "./LineageGraph";
+
+import "@xyflow/react/dist/style.css";
+import getGraphNodes from "./utils/getGraphNodes";
+import getGraphEdges from "./utils/getGraphEdges";
+import { LineageResponseV1 } from "@/dataProvider/types";
+
+type LineageViewProps = {
+    resource: string;
+    recordId: string | number;
+    defaultSince?: Date;
+    defaultDirection?: string;
+    granularities?: string[];
+};
+
+const LineageView = (props: LineageViewProps) => {
+    const dataProvider = useDataProvider();
+    const notify = useNotify();
+
+    const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
+    const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
+
+    const onSubmit = (values: {
+        since?: string;
+        until?: string;
+        depth?: number;
+        direction?: string;
+        granularity?: string;
+    }) => {
+        setNodes([]);
+        setNodes([]);
+
+        if (Object.keys(values).length > 0) {
+            dataProvider
+                .getLineage(props.resource, {
+                    id: props.recordId,
+                    filter: values,
+                })
+                .then((data: LineageResponseV1) => {
+                    const initialNodes = getGraphNodes(data);
+                    const initialEdges = getGraphEdges(data);
+                    const { nodes: layoutedNodes, edges: layoutedEdges } =
+                        buildLineageLayout({
+                            nodes: initialNodes,
+                            edges: initialEdges,
+                        });
+                    setNodes(layoutedNodes);
+                    setEdges(layoutedEdges);
+                })
+                .catch((error: Error) =>
+                    notify(error.message, { type: "error" }),
+                );
+        }
+    };
+
+    return (
+        <>
+            <LineageFilters onSubmit={onSubmit} {...props} />
+            {nodes && edges && (
+                <div style={{ height: "80vh" }}>
+                    <LineageGraph
+                        nodes={nodes}
+                        edges={edges}
+                        onNodesChange={onNodesChange}
+                        onEdgesChange={onEdgesChange}
+                    ></LineageGraph>
+                </div>
+            )}
+        </>
+    );
+};
+
+export default LineageView;

--- a/src/components/lineage/index.tsx
+++ b/src/components/lineage/index.tsx
@@ -1,0 +1,3 @@
+import LineageView from "./LineageView";
+
+export { LineageView };

--- a/src/components/lineage/nodes/BaseNode.tsx
+++ b/src/components/lineage/nodes/BaseNode.tsx
@@ -1,0 +1,78 @@
+import { Position, Handle, Edge, useReactFlow } from "@xyflow/react";
+import { ReactElement, ReactNode } from "react";
+
+import "./styles.css";
+
+import { Card, CardProps, Divider, Stack } from "@mui/material";
+
+const BaseNode = ({
+    nodeId,
+    icon,
+    header,
+    ...props
+}: {
+    nodeId: string;
+    icon: ReactNode;
+    header: ReactNode;
+} & CardProps): ReactElement => {
+    const { getEdges } = useReactFlow();
+
+    const isParent = (edge: Edge) => edge.data?.kind == "PARENT";
+
+    const hasInputs = getEdges().some(
+        (edge) => edge.source === nodeId && !isParent(edge),
+    );
+    const hasOutputs = getEdges().some(
+        (edge) => edge.target === nodeId && !isParent(edge),
+    );
+    const hasParents = getEdges().some(
+        (edge) => edge.target === nodeId && isParent(edge),
+    );
+    const hasChildren = getEdges().some(
+        (edge) => edge.source === nodeId && isParent(edge),
+    );
+
+    return (
+        <Card {...props}>
+            <Stack direction={"row"} sx={{ alignItems: "center" }}>
+                {icon}
+                <Divider orientation="vertical" flexItem />
+                {header}
+            </Stack>
+            {hasOutputs && (
+                <Handle
+                    type="target"
+                    id={"left"}
+                    position={Position.Left}
+                    isConnectable={false}
+                />
+            )}
+            {hasParents && (
+                <Handle
+                    type="target"
+                    id={"top"}
+                    position={Position.Top}
+                    isConnectable={false}
+                />
+            )}
+            {hasInputs && (
+                <Handle
+                    type="source"
+                    id={"right"}
+                    position={Position.Right}
+                    isConnectable={false}
+                />
+            )}
+            {hasChildren && (
+                <Handle
+                    type="source"
+                    id={"bottom"}
+                    position={Position.Bottom}
+                    isConnectable={false}
+                />
+            )}
+        </Card>
+    );
+};
+
+export default BaseNode;

--- a/src/components/lineage/nodes/DatasetNode.tsx
+++ b/src/components/lineage/nodes/DatasetNode.tsx
@@ -1,0 +1,51 @@
+import { NodeProps, Node } from "@xyflow/react";
+import { useCreatePath } from "react-admin";
+import { ReactElement, memo } from "react";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+
+import { DatasetResponseV1 } from "@/dataProvider/types";
+import { LocationIconWithType } from "@/components/location";
+import { Button, CardHeader } from "@mui/material";
+import BaseNode from "./BaseNode";
+
+export type DatasetNode = Node<DatasetResponseV1, "datasetNode">;
+
+const DatasetNode = memo((props: NodeProps<DatasetNode>): ReactElement => {
+    let title = props.data.name;
+    let subheader = `${props.data.location.type}://${props.data.location.name}`;
+    if (title.includes("/")) {
+        title = ".../" + title.substring(title.lastIndexOf("/") + 1);
+    }
+
+    const createPath = useCreatePath();
+    const path = createPath({
+        resource: "datasets",
+        type: "show",
+        id: props.data.id,
+    });
+
+    return (
+        <BaseNode
+            nodeId={props.id}
+            icon={
+                <LocationIconWithType
+                    location={props.data.location}
+                    sx={{ minWidth: "5em", alignItems: "center" }}
+                />
+            }
+            header={
+                <CardHeader
+                    title={title}
+                    subheader={subheader}
+                    action={
+                        <Button size="small" href={"#" + path}>
+                            <OpenInNewIcon />
+                        </Button>
+                    }
+                />
+            }
+        />
+    );
+});
+
+export default DatasetNode;

--- a/src/components/lineage/nodes/JobNode.tsx
+++ b/src/components/lineage/nodes/JobNode.tsx
@@ -1,0 +1,55 @@
+import { NodeProps, Node } from "@xyflow/react";
+import { useCreatePath } from "react-admin";
+import { ReactElement, memo } from "react";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+
+import { JobResponseV1 } from "@/dataProvider/types";
+import { Button, CardHeader } from "@mui/material";
+import BaseNode from "./BaseNode";
+import { JobIconWithType } from "@/components/job";
+
+export type JobNode = Node<JobResponseV1, "jobNode">;
+
+const JobNode = memo((props: NodeProps<JobNode>): ReactElement => {
+    let title = props.data.name;
+    let subheader = `${props.data.location.type}://${props.data.location.name}`;
+    if (props.data.name.includes("/")) {
+        title = props.data.name.substring(props.data.name.lastIndexOf("/") + 1);
+        subheader +=
+            "/" +
+            props.data.name.substring(0, props.data.name.lastIndexOf("/")) +
+            "/";
+    }
+
+    const createPath = useCreatePath();
+    const path = createPath({
+        resource: "jobs",
+        type: "show",
+        id: props.data.id,
+    });
+
+    return (
+        <BaseNode
+            nodeId={props.id}
+            icon={
+                <JobIconWithType
+                    job={props.data}
+                    sx={{ minWidth: "10em", alignItems: "center" }}
+                />
+            }
+            header={
+                <CardHeader
+                    title={title}
+                    subheader={subheader}
+                    action={
+                        <Button size="small" href={"#" + path}>
+                            <OpenInNewIcon />
+                        </Button>
+                    }
+                />
+            }
+        />
+    );
+});
+
+export default JobNode;

--- a/src/components/lineage/nodes/OperationNode.tsx
+++ b/src/components/lineage/nodes/OperationNode.tsx
@@ -1,0 +1,85 @@
+import { NodeProps, Node } from "@xyflow/react";
+import { useCreatePath } from "react-admin";
+import { ReactElement, memo } from "react";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+
+import { OperationResponseV1 } from "@/dataProvider/types";
+import {
+    Button,
+    CardHeader,
+    Chip,
+    Divider,
+    Stack,
+    Typography,
+} from "@mui/material";
+import BaseNode from "./BaseNode";
+import { OperationIcon } from "@/components/operation";
+import { formatDate, getDurationText } from "@/utils/datetime";
+import { statusToThemeColor } from "@/utils/color";
+
+export type OperationNode = Node<OperationResponseV1, "operationNode">;
+
+const OperationNode = memo((props: NodeProps<OperationNode>): ReactElement => {
+    const title = props.data.description ?? props.data.name;
+
+    const createdAt = formatDate(new Date(props.data.created_at));
+    const duration = getDurationText({
+        created_at: props.data.created_at,
+        started_at: props.data.started_at,
+        ended_at: props.data.ended_at,
+    });
+
+    const color = statusToThemeColor(props.data.status);
+
+    const createPath = useCreatePath();
+    const path = createPath({
+        resource: "operations",
+        type: "show",
+        id: props.data.id,
+    });
+
+    return (
+        <BaseNode
+            nodeId={props.id}
+            icon={
+                <OperationIcon
+                    operation={props.data}
+                    sx={{ minWidth: "5em", alignItems: "center" }}
+                />
+            }
+            header={
+                <CardHeader
+                    title={title}
+                    subheader={
+                        <Stack direction="row" spacing={1}>
+                            <Typography variant="subtitle1">
+                                {createdAt}
+                            </Typography>
+                            <Divider orientation="vertical" flexItem />
+                            <Chip
+                                color={color}
+                                size="small"
+                                label={props.data.status}
+                            />
+                            {duration && (
+                                <>
+                                    <Divider orientation="vertical" flexItem />
+                                    <Typography variant="subtitle1">
+                                        {duration}
+                                    </Typography>
+                                </>
+                            )}
+                        </Stack>
+                    }
+                    action={
+                        <Button size="small" href={"#" + path}>
+                            <OpenInNewIcon />
+                        </Button>
+                    }
+                />
+            }
+        />
+    );
+});
+
+export default OperationNode;

--- a/src/components/lineage/nodes/RunNode.tsx
+++ b/src/components/lineage/nodes/RunNode.tsx
@@ -1,0 +1,86 @@
+import { NodeProps, Node } from "@xyflow/react";
+import { useCreatePath } from "react-admin";
+import { ReactElement, memo } from "react";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+
+import { RunResponseV1 } from "@/dataProvider/types";
+import {
+    Button,
+    CardHeader,
+    Chip,
+    Divider,
+    Stack,
+    Typography,
+} from "@mui/material";
+import BaseNode from "./BaseNode";
+import { RunIcon } from "@/components/run";
+import { formatDate, getDurationText } from "@/utils/datetime";
+import { statusToThemeColor } from "@/utils/color";
+
+export type RunNode = Node<RunResponseV1, "runNode">;
+
+const RunNode = memo((props: NodeProps<RunNode>): ReactElement => {
+    const createdAt = formatDate(new Date(props.data.created_at));
+
+    const title = props.data.external_id ? props.data.external_id : createdAt;
+    const subheader = props.data.external_id ? createdAt : "";
+    const color = statusToThemeColor(props.data.status);
+
+    const duration = getDurationText({
+        created_at: props.data.created_at,
+        started_at: props.data.started_at,
+        ended_at: props.data.ended_at,
+    });
+
+    const createPath = useCreatePath();
+    const path = createPath({
+        resource: "runs",
+        type: "show",
+        id: props.data.id,
+    });
+
+    return (
+        <BaseNode
+            nodeId={props.id}
+            icon={
+                <RunIcon
+                    run={props.data}
+                    sx={{ minWidth: "5em", alignItems: "center" }}
+                />
+            }
+            header={
+                <CardHeader
+                    title={title}
+                    subheader={
+                        <Stack direction="row" spacing={1}>
+                            <Typography variant="subtitle1">
+                                {subheader}
+                            </Typography>
+                            <Divider orientation="vertical" flexItem />
+                            <Chip
+                                color={color}
+                                size="small"
+                                label={props.data.status}
+                            />
+                            {duration && (
+                                <>
+                                    <Divider orientation="vertical" flexItem />
+                                    <Typography variant="subtitle1">
+                                        {duration}
+                                    </Typography>
+                                </>
+                            )}
+                        </Stack>
+                    }
+                    action={
+                        <Button size="small" href={"#" + path}>
+                            <OpenInNewIcon />
+                        </Button>
+                    }
+                />
+            }
+        />
+    );
+});
+
+export default RunNode;

--- a/src/components/lineage/nodes/index.ts
+++ b/src/components/lineage/nodes/index.ts
@@ -1,0 +1,6 @@
+import DatasetNode from "./DatasetNode";
+import JobNode from "./JobNode";
+import RunNode from "./RunNode";
+import OperationNode from "./OperationNode";
+
+export { DatasetNode, JobNode, RunNode, OperationNode };

--- a/src/components/lineage/nodes/styles.css
+++ b/src/components/lineage/nodes/styles.css
@@ -1,0 +1,4 @@
+.react-flow__node.selected .MuiCard-root {
+    background-color: var(--xy-selection-background-color-default);
+    border-color: var(--xy-selection-border-default);
+}

--- a/src/components/lineage/utils/buildLayout.ts
+++ b/src/components/lineage/utils/buildLayout.ts
@@ -1,0 +1,53 @@
+import dagre from "@dagrejs/dagre";
+import { Node, Edge } from "@xyflow/react";
+
+const NODE_SEPARATOR = 100;
+const NODE_WIDTH = 800;
+const NODE_HEIGHT = 90;
+const LINEAGE_DIRECTION_HORIZONTAL = "LR";
+
+const buildLineageLayout = ({
+    nodes,
+    edges,
+}: {
+    nodes: Node[];
+    edges: Edge[];
+}): { nodes: Node[]; edges: Edge[] } => {
+    const dagreGraph = new dagre.graphlib.Graph();
+    dagreGraph.setDefaultEdgeLabel(() => ({}));
+
+    dagreGraph.setGraph({
+        rankdir: LINEAGE_DIRECTION_HORIZONTAL,
+        nodesep: NODE_SEPARATOR,
+    });
+
+    nodes.forEach((node) => {
+        dagreGraph.setNode(node.id, {
+            width: node.measured?.width ?? node.width ?? NODE_WIDTH,
+            height: node.measured?.height ?? node.height ?? NODE_HEIGHT,
+        });
+    });
+
+    edges.forEach((edge) => {
+        dagreGraph.setEdge(edge.source, edge.target);
+    });
+
+    dagre.layout(dagreGraph, { minlen: 2 });
+
+    const newNodes = nodes.map((node) => {
+        const nodeWithPosition = dagreGraph.node(node.id);
+        return {
+            ...(node as Node),
+            // We are shifting the dagre node position (anchor=center center) to the top left
+            // so it matches the React Flow node anchor point (top left).
+            position: {
+                x: nodeWithPosition.x - nodeWithPosition.width / 2,
+                y: nodeWithPosition.y - nodeWithPosition.height / 2,
+            },
+        };
+    });
+
+    return { nodes: newNodes, edges };
+};
+
+export default buildLineageLayout;

--- a/src/components/lineage/utils/getGraphEdges.ts
+++ b/src/components/lineage/utils/getGraphEdges.ts
@@ -1,0 +1,197 @@
+import {
+    LineageRelationResponseV1,
+    OutputRelationLineageResponseV1,
+    SymlinkRelationLineageResponseV1,
+    InputRelationLineageResponseV1,
+    ParentRelationLineageResponseV1,
+    BaseRelationLineageResponseV1,
+    LineageResponseV1,
+} from "@/dataProvider/types";
+import { Edge, MarkerType } from "@xyflow/react";
+import { getNodeId } from "./getGraphNodes";
+
+const STOKE_THICK = 3;
+const STOKE_THIN = 1;
+
+export const getEdgeId = (relation: BaseRelationLineageResponseV1): string => {
+    // @ts-ignore
+    const type = relation.type ?? "";
+    return `${getNodeId(relation.from)}-${type}->${getNodeId(relation.to)}`;
+};
+
+const getMinimalEdge = (
+    relation: BaseRelationLineageResponseV1,
+    raw_response: LineageResponseV1,
+): Edge => {
+    return {
+        id: getEdgeId(relation),
+        source: getNodeId(relation.from),
+        target: getNodeId(relation.to),
+        // @ts-ignore
+        data: relation,
+        markerEnd: {
+            type: MarkerType.ArrowClosed,
+        },
+        style: {
+            strokeWidth: STOKE_THIN,
+            stroke: "black",
+        },
+    };
+};
+
+const getParentEdge = (
+    relation: ParentRelationLineageResponseV1,
+    raw_response: LineageResponseV1,
+): Edge => {
+    return {
+        ...getMinimalEdge(relation, raw_response),
+        sourceHandle: "bottom",
+        targetHandle: "top",
+        label: "PARENT",
+    };
+};
+
+const getOutputEdge = (
+    relation: OutputRelationLineageResponseV1,
+    raw_response: LineageResponseV1,
+): Edge => {
+    let color = "green";
+    switch (relation.type) {
+        case "DROP":
+        case "TRUNCATE":
+            color = "red";
+            break;
+        case "ALTER":
+        case "RENAME":
+            color = "yellow";
+            break;
+        default:
+            color = "green";
+    }
+
+    return {
+        ...getMinimalEdge(relation, raw_response),
+        animated: true,
+        label: relation.type,
+        markerEnd: {
+            type: MarkerType.ArrowClosed,
+            color: color,
+        },
+        style: {
+            strokeWidth: STOKE_THICK,
+            stroke: color,
+        },
+    };
+};
+
+const getInputEdge = (
+    relation: InputRelationLineageResponseV1,
+    raw_response: LineageResponseV1,
+): Edge => {
+    const color = "green";
+    return {
+        ...getMinimalEdge(relation, raw_response),
+        animated: true,
+        markerEnd: {
+            type: MarkerType.ArrowClosed,
+            color: color,
+        },
+        style: {
+            strokeWidth: STOKE_THICK,
+            stroke: color,
+        },
+    };
+};
+
+const getSymlinkEdge = (
+    relation: SymlinkRelationLineageResponseV1,
+    raw_response: LineageResponseV1,
+): Edge | null => {
+    if (relation.type == "METASTORE") {
+        // having 2 edges between same nodes leads to confusing cross links like those:
+        //
+        // >HDFS<
+        //  \  /
+        //   \/
+        //   /\
+        //  /  \
+        // >Hive<
+        //
+        // To avoid that, keep only one symlink, at least for now.
+        return null;
+    }
+
+    // if target node has only outputs (e.g. HDFS is a source for all jobs/runs/... in this graph),
+    // draw symlink on the left, to replace complex graphs like these:
+    //
+    //     /--> Job
+    // HDFS
+    //     \
+    //      <-> Hive
+    //
+    // with more simple graphs, like these:
+    //
+    // Hive <-> HDFS -> Job
+    const targetRelations = raw_response.relations.filter(
+        (r) => r.to.id == relation.to.id || r.from.id == relation.to.id,
+    );
+    const targetHasOnlyOutputs = targetRelations.every(
+        (r) => r.kind == "OUTPUT" || r.kind == "SYMLINK",
+    );
+
+    return {
+        ...getMinimalEdge(relation, raw_response),
+        label: "SYMLINK",
+        source: targetHasOnlyOutputs
+            ? getNodeId(relation.to)
+            : getNodeId(relation.from),
+        target: targetHasOnlyOutputs
+            ? getNodeId(relation.from)
+            : getNodeId(relation.to),
+        markerStart: {
+            type: MarkerType.ArrowClosed,
+            color: "purple",
+        },
+        markerEnd: {
+            type: MarkerType.ArrowClosed,
+            color: "purple",
+        },
+        style: {
+            strokeWidth: STOKE_THIN,
+            stroke: "purple",
+        },
+    };
+};
+
+const getGraphEdge = (
+    relation: LineageRelationResponseV1,
+    raw_response: LineageResponseV1,
+): Edge | null => {
+    switch (relation.kind) {
+        case "PARENT":
+            return getParentEdge(relation, raw_response);
+        case "OUTPUT":
+            return getOutputEdge(relation, raw_response);
+        case "INPUT":
+            return getInputEdge(relation, raw_response);
+        case "SYMLINK":
+            return getSymlinkEdge(relation, raw_response);
+        default:
+            return getMinimalEdge(relation, raw_response);
+    }
+};
+
+const getGraphEdges = (raw_response: LineageResponseV1): Edge[] => {
+    const result: Edge[] = [];
+
+    raw_response.relations.forEach((relation) => {
+        const edge = getGraphEdge(relation, raw_response);
+        if (edge) {
+            result.push(edge);
+        }
+    });
+
+    return result;
+};
+
+export default getGraphEdges;

--- a/src/components/lineage/utils/getGraphNodes.ts
+++ b/src/components/lineage/utils/getGraphNodes.ts
@@ -1,0 +1,88 @@
+import {
+    LineageNodeResponseV1,
+    LineageResponseV1,
+    RelationEndpointLineageResponseV1,
+} from "@/dataProvider/types";
+import { Node } from "@xyflow/react";
+
+export const getNodeId = (
+    node: LineageNodeResponseV1 | RelationEndpointLineageResponseV1,
+): string => {
+    return node.kind + "-" + node.id;
+};
+
+const getDefaultNode = (
+    node: LineageNodeResponseV1,
+    raw_response: LineageResponseV1,
+): Node => {
+    return {
+        id: getNodeId(node),
+        type: "default",
+        position: { x: 0, y: 0 },
+        data: node,
+    };
+};
+
+const getDataseNode = (
+    node: LineageNodeResponseV1,
+    raw_response: LineageResponseV1,
+): Node => {
+    return {
+        ...getDefaultNode(node, raw_response),
+        type: "datasetNode",
+    };
+};
+
+const getJobNode = (
+    node: LineageNodeResponseV1,
+    raw_response: LineageResponseV1,
+): Node => {
+    return {
+        ...getDefaultNode(node, raw_response),
+        type: "jobNode",
+    };
+};
+
+const getRunNode = (
+    node: LineageNodeResponseV1,
+    raw_response: LineageResponseV1,
+): Node => {
+    return {
+        ...getDefaultNode(node, raw_response),
+        type: "runNode",
+    };
+};
+
+const getOperationNode = (
+    node: LineageNodeResponseV1,
+    raw_response: LineageResponseV1,
+): Node => {
+    return {
+        ...getDefaultNode(node, raw_response),
+        type: "operationNode",
+    };
+};
+
+const getGraphNode = (
+    node: LineageNodeResponseV1,
+    raw_response: LineageResponseV1,
+): Node => {
+    switch (node.kind) {
+        case "DATASET":
+            return getDataseNode(node, raw_response);
+        case "JOB":
+            return getJobNode(node, raw_response);
+        case "RUN":
+            return getRunNode(node, raw_response);
+        case "OPERATION":
+            return getOperationNode(node, raw_response);
+        default:
+            return getDefaultNode(node, raw_response);
+    }
+};
+
+const getGraphNodes = (raw_response: LineageResponseV1): Node[] => {
+    return raw_response.nodes.map((node) => getGraphNode(node, raw_response));
+};
+
+export default getGraphNodes;

--- a/src/components/operation/OperationIcon.tsx
+++ b/src/components/operation/OperationIcon.tsx
@@ -1,0 +1,21 @@
+import { ReactElement } from "react";
+import { Stack, StackProps } from "@mui/material";
+import HandymanIcon from "@mui/icons-material/Handyman";
+import { useTranslate } from "react-admin";
+import { OperationResponseV1 } from "@/dataProvider/types";
+
+const OperationIcon = ({
+    operation,
+    ...props
+}: { operation: OperationResponseV1 } & StackProps): ReactElement => {
+    const translate = useTranslate();
+    return (
+        <Stack direction={"column"} {...props}>
+            {<HandymanIcon />}
+            <span>
+                {translate("resources.operations.name", { smart_count: 1 })}
+            </span>
+        </Stack>
+    );
+};
+export default OperationIcon;

--- a/src/components/operation/OperationRaLineage.tsx
+++ b/src/components/operation/OperationRaLineage.tsx
@@ -1,0 +1,22 @@
+import { useRecordContext } from "react-admin";
+
+import { LineageView } from "@/components/lineage";
+import { ReactFlowProvider } from "@xyflow/react";
+
+const OperationRaLineage = () => {
+    const record = useRecordContext();
+    if (!record) {
+        return null;
+    }
+    return (
+        <ReactFlowProvider>
+            <LineageView
+                resource="operations"
+                recordId={record.id}
+                defaultSince={record.created_at as Date}
+            />
+        </ReactFlowProvider>
+    );
+};
+
+export default OperationRaLineage;

--- a/src/components/operation/OperationRaListForRun.tsx
+++ b/src/components/operation/OperationRaListForRun.tsx
@@ -41,12 +41,7 @@ const OperationRaListForRun = ({
                     sortable={false}
                 />
                 <StatusField source="status" sortable={false} />
-                <DurationField
-                    source="duration"
-                    start_field="started_at"
-                    end_field="ended_at"
-                    sortable={false}
-                />
+                <DurationField source="duration" sortable={false} />
             </DatagridConfigurable>
         </List>
     );

--- a/src/components/operation/OperationRaShow.tsx
+++ b/src/components/operation/OperationRaShow.tsx
@@ -6,9 +6,11 @@ import {
     ReferenceField,
     Show,
     SimpleShowLayout,
+    TabbedShowLayout,
     TextField,
 } from "react-admin";
 import { DurationField, StatusField } from "@/components/base";
+import OperationRaLineage from "./OperationRaLineage";
 
 const OperationRaShow = (): ReactElement => {
     return (
@@ -51,14 +53,16 @@ const OperationRaShow = (): ReactElement => {
                             <DateField source="ended_at" showTime={true} />
                         </Labeled>
                         <Labeled label="resources.operations.sections.duration">
-                            <DurationField
-                                source="duration"
-                                start_field="started_at"
-                                end_field="ended_at"
-                            />
+                            <DurationField source="duration" />
                         </Labeled>
                     </Stack>
                 </Labeled>
+
+                <TabbedShowLayout>
+                    <TabbedShowLayout.Tab label="resources.operations.tabs.lineage">
+                        <OperationRaLineage />
+                    </TabbedShowLayout.Tab>
+                </TabbedShowLayout>
             </SimpleShowLayout>
         </Show>
     );

--- a/src/components/operation/index.ts
+++ b/src/components/operation/index.ts
@@ -1,4 +1,5 @@
 import OperationRaShow from "./OperationRaShow";
 import OperationRaListForRun from "./OperationRaListForRun";
+import OperationIcon from "./OperationIcon";
 
-export { OperationRaShow, OperationRaListForRun };
+export { OperationRaShow, OperationRaListForRun, OperationIcon };

--- a/src/components/run/RunIcon.tsx
+++ b/src/components/run/RunIcon.tsx
@@ -1,0 +1,19 @@
+import { ReactElement } from "react";
+import { Stack, StackProps } from "@mui/material";
+import { PlayArrow } from "@mui/icons-material";
+import { useTranslate } from "react-admin";
+import { RunResponseV1 } from "@/dataProvider/types";
+
+const RunIcon = ({
+    run,
+    ...props
+}: { run: RunResponseV1 } & StackProps): ReactElement => {
+    const translate = useTranslate();
+    return (
+        <Stack direction={"column"} {...props}>
+            {<PlayArrow />}
+            <span>{translate("resources.runs.name", { smart_count: 1 })}</span>
+        </Stack>
+    );
+};
+export default RunIcon;

--- a/src/components/run/RunRaLineage.tsx
+++ b/src/components/run/RunRaLineage.tsx
@@ -1,0 +1,23 @@
+import { useRecordContext } from "react-admin";
+
+import { LineageView } from "@/components/lineage";
+import { ReactFlowProvider } from "@xyflow/react";
+
+const RunLineage = () => {
+    const record = useRecordContext();
+    if (!record) {
+        return null;
+    }
+    return (
+        <ReactFlowProvider>
+            <LineageView
+                resource="runs"
+                recordId={record.id}
+                defaultSince={record.created_at as Date}
+                granularities={["RUN", "OPERATION"]}
+            />
+        </ReactFlowProvider>
+    );
+};
+
+export default RunLineage;

--- a/src/components/run/RunRaList.tsx
+++ b/src/components/run/RunRaList.tsx
@@ -43,12 +43,7 @@ const RunRaList = (): ReactElement => {
                     sortable={false}
                 />
                 <StatusField source="status" sortable={false} />
-                <DurationField
-                    source="duration"
-                    start_field="started_at"
-                    end_field="ended_at"
-                    sortable={false}
-                />
+                <DurationField source="duration" sortable={false} />
                 <WrapperField source="started_by_user" sortable={false}>
                     <TextField source="started_by_user.name" />
                 </WrapperField>

--- a/src/components/run/RunRaListForJob.tsx
+++ b/src/components/run/RunRaListForJob.tsx
@@ -42,12 +42,7 @@ const RunRaListForJob = ({ jobId }: { jobId: number }): ReactElement => {
                 />
                 {/* Do not show job, as we already in JobShow page*/}
                 <StatusField source="status" sortable={false} />
-                <DurationField
-                    source="duration"
-                    start_field="started_at"
-                    end_field="ended_at"
-                    sortable={false}
-                />
+                <DurationField source="duration" sortable={false} />
                 <WrapperField source="started_by_user" sortable={false}>
                     <TextField source="started_by_user.name" />
                 </WrapperField>

--- a/src/components/run/RunRaShow.tsx
+++ b/src/components/run/RunRaShow.tsx
@@ -1,4 +1,4 @@
-import { Divider, Stack } from "@mui/material";
+import { Stack } from "@mui/material";
 import { ReactElement } from "react";
 import {
     DateField,
@@ -7,18 +7,17 @@ import {
     RichTextField,
     Show,
     SimpleShowLayout,
+    TabbedShowLayout,
     TextField,
     UrlField,
-    useTranslate,
     WithRecord,
     WrapperField,
 } from "react-admin";
 import { DurationField, StatusField } from "@/components/base";
 import { OperationRaListForRun } from "@/components/operation";
+import RunRaLineage from "./RunRaLineage";
 
 const RunRaShow = (): ReactElement => {
-    const translate = useTranslate();
-
     return (
         <Show>
             <SimpleShowLayout>
@@ -67,11 +66,7 @@ const RunRaShow = (): ReactElement => {
                             <RichTextField source="end_reason" />
                         </Labeled>
                         <Labeled label="resources.runs.sections.duration">
-                            <DurationField
-                                source="duration"
-                                start_field="started_at"
-                                end_field="ended_at"
-                            />
+                            <DurationField source="duration" />
                         </Labeled>
                     </Stack>
                 </Labeled>
@@ -93,13 +88,22 @@ const RunRaShow = (): ReactElement => {
                     </Stack>
                 </Labeled>
 
-                <Divider>
-                    {translate("resources.runs.sections.operations")}
-                </Divider>
+                <TabbedShowLayout>
+                    <TabbedShowLayout.Tab label="resources.runs.tabs.operations">
+                        <WithRecord
+                            render={(record) => (
+                                <OperationRaListForRun run={record} />
+                            )}
+                        />
+                    </TabbedShowLayout.Tab>
 
-                <WithRecord
-                    render={(record) => <OperationRaListForRun run={record} />}
-                />
+                    <TabbedShowLayout.Tab
+                        label="resources.runs.tabs.lineage"
+                        path="lineage"
+                    >
+                        <RunRaLineage />
+                    </TabbedShowLayout.Tab>
+                </TabbedShowLayout>
             </SimpleShowLayout>
         </Show>
     );

--- a/src/components/run/index.ts
+++ b/src/components/run/index.ts
@@ -1,5 +1,6 @@
 import RunRaShow from "./RunRaShow";
 import RunRaList from "./RunRaList";
 import RunRaListForJob from "./RunRaListForJob";
+import RunIcon from "./RunIcon";
 
-export { RunRaShow, RunRaList, RunRaListForJob };
+export { RunRaShow, RunRaList, RunRaListForJob, RunIcon };

--- a/src/dataProvider/types.ts
+++ b/src/dataProvider/types.ts
@@ -82,10 +82,88 @@ interface OperationResponseV1 extends RaRecord {
     ended_at: string | null;
 }
 
+type EntityTypeLineageResponseV1 = "DATASET" | "JOB" | "RUN" | "OPERATION";
+
+interface RelationEndpointLineageResponseV1 {
+    kind: EntityTypeLineageResponseV1;
+    id: number | string;
+}
+
+interface BaseRelationLineageResponseV1 {
+    kind: string;
+    from: RelationEndpointLineageResponseV1;
+    to: RelationEndpointLineageResponseV1;
+}
+
+interface InputRelationLineageResponseV1 extends BaseRelationLineageResponseV1 {
+    kind: "INPUT";
+}
+
+type OutputRelationTypeLineageResponseV1 =
+    | "ALTER"
+    | "CREATE"
+    | "DROP"
+    | "OVERWRITE"
+    | "RENAME"
+    | "TRUNCATE";
+
+interface OutputRelationLineageResponseV1
+    extends BaseRelationLineageResponseV1 {
+    kind: "OUTPUT";
+    type: OutputRelationTypeLineageResponseV1;
+}
+
+interface ParentRelationLineageResponseV1
+    extends BaseRelationLineageResponseV1 {
+    kind: "PARENT";
+}
+
+type SymlinkRelationTypeLineageResponseV1 = "METASTORE" | "WAREHOUSE";
+
+interface SymlinkRelationLineageResponseV1
+    extends BaseRelationLineageResponseV1 {
+    kind: "SYMLINK";
+    type: SymlinkRelationTypeLineageResponseV1;
+}
+
+type LineageRelationResponseV1 =
+    | InputRelationLineageResponseV1
+    | OutputRelationLineageResponseV1
+    | ParentRelationLineageResponseV1
+    | SymlinkRelationLineageResponseV1;
+
+type LineageNodeResponseV1 =
+    | DatasetResponseV1
+    | JobResponseV1
+    | RunResponseV1
+    | OperationResponseV1;
+
+type LineageResponseV1 = {
+    nodes: LineageNodeResponseV1[];
+    relations: LineageRelationResponseV1[];
+};
+
 export type {
     LocationResponseV1,
     DatasetResponseV1,
     JobResponseV1,
     RunResponseV1,
     OperationResponseV1,
+    LineageNodeResponseV1,
+    LineageRelationResponseV1,
+    LineageResponseV1,
+    UserResponseV1,
+    StatusResponseV1,
+    StartReasonResponseV1,
+    JobTypeResponseV1,
+    OperationTypeResponseV1,
+    EntityTypeLineageResponseV1,
+    RelationEndpointLineageResponseV1,
+    BaseRelationLineageResponseV1,
+    InputRelationLineageResponseV1,
+    OutputRelationLineageResponseV1,
+    OutputRelationTypeLineageResponseV1,
+    ParentRelationLineageResponseV1,
+    SymlinkRelationLineageResponseV1,
+    SymlinkRelationTypeLineageResponseV1,
 };

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -60,6 +60,9 @@ const customEnglishMessages: TranslationMessages = {
                     type: "Location Type",
                 },
             },
+            tabs: {
+                lineage: "Lineage",
+            },
             filters: {
                 search_query: {
                     label: "Search",
@@ -85,8 +88,9 @@ const customEnglishMessages: TranslationMessages = {
                     type: "Location Type",
                 },
             },
-            sections: {
+            tabs: {
                 runs: "Runs",
+                lineage: "Lineage",
             },
             filters: {
                 search_query: {
@@ -130,7 +134,10 @@ const customEnglishMessages: TranslationMessages = {
                 attempt: "Attempt",
                 external_url: "External URL",
                 logs_url: "Logs URL",
+            },
+            tabs: {
                 operations: "Operations",
+                lineage: "Lineage",
             },
             filters: {
                 since: {
@@ -178,6 +185,9 @@ const customEnglishMessages: TranslationMessages = {
                 when: "When",
                 duration: "Duration",
             },
+            tabs: {
+                lineage: "Lineage",
+            },
             filters: {
                 since: {
                     label: "Since",
@@ -193,6 +203,37 @@ const customEnglishMessages: TranslationMessages = {
     },
     errors: {
         fetch: "Cannot fetch %{resource}",
+    },
+    lineage: {
+        filters: {
+            since: {
+                label: "Since",
+                helperText: "Include only events created after",
+            },
+            until: {
+                label: "Until",
+                helperText: "Include only events created before",
+            },
+            depth: {
+                label: "Depth",
+                helperText: "How many levels of events to include",
+            },
+            direction: {
+                label: "Direction",
+                helperText: "Include only events with specific direction",
+                both: "Downstream & upstream",
+                downstream: "Downstream",
+                upstream: "Upstream",
+            },
+            granularity: {
+                label: "Granularity",
+                helperText: "Include only events with specific granularity",
+                job: "Job",
+                run: "Run",
+                operation: "Operation",
+            },
+        },
+        build_button: "Build lineage graph",
     },
 };
 

--- a/src/utils/color.ts
+++ b/src/utils/color.ts
@@ -1,0 +1,15 @@
+export const statusToThemeColor = (
+    status: string,
+): "primary" | "success" | "error" | "warning" => {
+    switch (status) {
+        case "SUCCEEDED":
+            return "success";
+        case "FAILED":
+        case "KILLED":
+            return "error";
+        case "UNKNOWN":
+            return "warning";
+        default:
+            return "primary";
+    }
+};

--- a/src/utils/datetime.ts
+++ b/src/utils/datetime.ts
@@ -1,0 +1,43 @@
+// Get time interval between two dates
+const getTimeIntervalText = (startTime: Date, endTime: Date): string => {
+    // @ts-ignore
+    const differenceInSeconds = Math.abs(endTime - startTime) / 1000;
+
+    const hours = Math.floor(differenceInSeconds / 60 / 60);
+    const minutes = Math.floor(differenceInSeconds / 60) - hours * 60;
+    const seconds =
+        Math.floor(differenceInSeconds) - hours * 60 * 60 - minutes * 60;
+
+    if (hours) return `${hours}h ${minutes}m ${seconds}s`;
+    if (minutes) return `${minutes}m ${seconds}s`;
+    return `${seconds}s`;
+};
+
+// Get duration for specific set of fields
+export const getDurationText = ({
+    created_at,
+    started_at,
+    ended_at,
+}: {
+    created_at: string;
+    started_at: string | null;
+    ended_at: string | null;
+}): string | null => {
+    const start_time = started_at || created_at;
+    const end_time = ended_at;
+
+    if (!start_time || !end_time) {
+        return null;
+    }
+
+    return getTimeIntervalText(new Date(start_time), new Date(end_time));
+};
+
+export const formatDate = (date: Date): string => {
+    const dateFormatOptions = {
+        dateStyle: "short",
+        timeStyle: "long",
+    } as Intl.DateTimeFormatOptions;
+
+    return date.toLocaleString(undefined, dateFormatOptions);
+};


### PR DESCRIPTION
Implement lineage components. Based on [ReactFlow](https://reactflow.dev/learn).

- `LineageGraph` is base component for displaying lineage graph. It also supports pan, zoom, and has a minimap to simplify navigation.
- `LineageView` is component which fetches linages data using user defined filters, and passes all the data to `LineageGraph`. Functions `getGraphNodes` & `getGraphEdges` are used convert API representation of graph to ReactFlow representation.
- DatasetNode, JobNode, RunNode, OperationNode are implemented as cards with icon + title + short description. RunNode & OperationNode share some implementation details, for now.
- ReactFlow does require predefined position of all Nodes. For now, using [darge](https://github.com/dagrejs/dagre) to automatically calculate proper graph layout based on relations and fixed node width+height.
- Added `LineageView` components to all Show components. Some components already have some child list components here, so I've moved them to different tabs.

Here is the result.

Dataset show page:
![Снимок экрана_20241105_184644-1](https://github.com/user-attachments/assets/f52bd5d4-62da-4430-a476-1d0c3c22f76d)

Job show page:
![Снимок экрана_20241105_184308-1](https://github.com/user-attachments/assets/12e049ac-d624-42d8-9725-57491d55c968)

Run show page:
![Снимок экрана_20241105_184437-1](https://github.com/user-attachments/assets/e5e88372-7f6f-4795-80b7-d86eae1e084a)


For now implementation is far from ideal, ans some things are not implemented:
- Currently there is no dataset schema (e.g. dropdown action in DatasetNode card). 
- *dagre* does not allow to set rules for layout, so DatasetNode, JobNode and RunNode are all aligned on left side of the lineage view.
- While selecting some node, related nodes are not highlighted.