### PR TITLE
[DOP-21296] Add child runs list to RunRaShow page

### DIFF
--- a/src/components/run/RunRaListForParentRun.tsx
+++ b/src/components/run/RunRaListForParentRun.tsx
@@ -1,0 +1,66 @@
+import { ReactElement, useState } from "react";
+import {
+    List,
+    DatagridConfigurable,
+    DateField,
+    ReferenceField,
+    WrapperField,
+    TextField,
+} from "react-admin";
+
+import { DurationField, StatusField, ListActions } from "@/components/base";
+import RunRaExternalId from "./RunRaExternalId";
+import RunRaListFilters from "./RunRaListFilters";
+import { RunResponseV1 } from "@/dataProvider/types";
+
+const RunRaListForParentRun = ({
+    parentRun,
+}: {
+    parentRun: RunResponseV1;
+}): ReactElement => {
+    // Hack to avoid sending any network requests until user passed all required filters
+    // See https://github.com/marmelab/react-admin/issues/10286
+    const [enabled, setEnabled] = useState(false);
+
+    return (
+        <List
+            resource="runs"
+            filter={{ parent_run_id: parentRun.id }}
+            filterDefaultValues={{ since: parentRun.created_at }}
+            actions={
+                <ListActions>
+                    <RunRaListFilters
+                        isReadyCallback={setEnabled}
+                        requiredFilters={["since"]}
+                    />
+                </ListActions>
+            }
+            queryOptions={{ enabled }}
+            title={false}
+            /* Reset filters on every RunRaShow page */
+            disableSyncWithLocation
+        >
+            <DatagridConfigurable bulkActionButtons={false}>
+                <DateField
+                    source="created_at"
+                    showTime={true}
+                    sortable={false}
+                />
+                <ReferenceField
+                    source="job_id"
+                    reference="jobs"
+                    sortable={false}
+                />
+                <StatusField source="status" sortable={false} />
+                <DurationField source="duration" sortable={false} />
+                <WrapperField source="started_by_user" sortable={false}>
+                    <TextField source="started_by_user.name" />
+                </WrapperField>
+                <RunRaExternalId source="external_id" sortable={false} />
+                {/* Do not show parent_run, as we already in parent RunShow page*/}
+            </DatagridConfigurable>
+        </List>
+    );
+};
+
+export default RunRaListForParentRun;

--- a/src/components/run/RunRaShow.tsx
+++ b/src/components/run/RunRaShow.tsx
@@ -16,6 +16,7 @@ import {
 import { DurationField, StatusField } from "@/components/base";
 import { OperationRaListForRun } from "@/components/operation";
 import RunRaLineage from "./RunRaLineage";
+import RunRaListForParentRun from "./RunRaListForParentRun";
 
 const RunRaShow = (): ReactElement => {
     return (
@@ -93,6 +94,14 @@ const RunRaShow = (): ReactElement => {
                         <WithRecord
                             render={(record) => (
                                 <OperationRaListForRun run={record} />
+                            )}
+                        />
+                    </TabbedShowLayout.Tab>
+
+                    <TabbedShowLayout.Tab label="resources.runs.tabs.child_runs">
+                        <WithRecord
+                            render={(record) => (
+                                <RunRaListForParentRun parentRun={record} />
                             )}
                         />
                     </TabbedShowLayout.Tab>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -137,6 +137,7 @@ const customEnglishMessages: TranslationMessages = {
             },
             tabs: {
                 operations: "Operations",
+                child_runs: "Child runs",
                 lineage: "Lineage",
             },
             filters: {


### PR DESCRIPTION
Add `RunRaListForParentRun` component which renders list of child runs for specific parentRun. Added this component to "Child runs" tab of `RunRaShow` page.

Here is a screenshot with Airflow dag run page, listing its child Airflow task runs:
![Снимок экрана_20241107_155440-1](https://github.com/user-attachments/assets/2d2f0d4f-4218-44ba-95aa-00a421f114a9)
