### PR TITLE
[DOP-20148] Show amount of data on edge label

### DIFF
--- a/src/components/lineage/LineageGraph.tsx
+++ b/src/components/lineage/LineageGraph.tsx
@@ -10,9 +10,15 @@ import {
 } from "@xyflow/react";
 import { DatasetNode, JobNode, RunNode, OperationNode } from "./nodes";
 import { useEffect } from "react";
+import { BaseEdge, IOEdge } from "./edges";
 
 export const MIN_ZOOM_VALUE = 0.1;
 export const MAX_ZOOM_VALUE = 2.5;
+
+const edgeTypes = {
+    ioEdge: IOEdge,
+    baseEdge: BaseEdge,
+};
 
 const nodeTypes = {
     datasetNode: DatasetNode,
@@ -33,6 +39,7 @@ const LineageGraph = (props: ReactFlowProps) => {
     return (
         <ReactFlow
             nodeTypes={nodeTypes}
+            edgeTypes={edgeTypes}
             nodesFocusable={true}
             elementsSelectable={true}
             nodesConnectable={false}

--- a/src/components/lineage/edges/BaseEdge.tsx
+++ b/src/components/lineage/edges/BaseEdge.tsx
@@ -1,0 +1,39 @@
+import { ReactElement } from "react";
+import {
+    getBezierPath,
+    EdgeLabelRenderer,
+    BaseEdge as ReactFlowBaseEdge,
+    EdgeProps,
+} from "@xyflow/react";
+import { Chip } from "@mui/material";
+
+const BaseEdge = ({ id, label, ...props }: EdgeProps): ReactElement => {
+    const [edgePath, labelX, labelY] = getBezierPath(props);
+
+    return (
+        <>
+            <ReactFlowBaseEdge id={id} path={edgePath} {...props} />
+            {label && (
+                <EdgeLabelRenderer>
+                    <div
+                        style={{
+                            // required to place label exactly on the edge
+                            position: "absolute",
+                            transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+                        }}
+                        className="nodrag nopan"
+                    >
+                        <Chip
+                            size="small"
+                            color="info"
+                            label={label}
+                            style={props.labelStyle}
+                        />
+                    </div>
+                </EdgeLabelRenderer>
+            )}
+        </>
+    );
+};
+
+export default BaseEdge;

--- a/src/components/lineage/edges/IOEdge.tsx
+++ b/src/components/lineage/edges/IOEdge.tsx
@@ -1,0 +1,67 @@
+import { ReactElement } from "react";
+import {
+    getBezierPath,
+    EdgeLabelRenderer,
+    BaseEdge,
+    EdgeProps,
+} from "@xyflow/react";
+import {
+    InputRelationLineageResponseV1,
+    OutputRelationLineageResponseV1,
+} from "@/dataProvider/types";
+import formatNumberApprox from "@/utils/numbers";
+import formatBytes from "@/utils/bytes";
+import { Card, Chip, Typography } from "@mui/material";
+
+const IOEdge = ({
+    id,
+    label,
+    data,
+    ...props
+}: EdgeProps & {
+    data: InputRelationLineageResponseV1 | OutputRelationLineageResponseV1;
+}): ReactElement => {
+    const [edgePath, labelX, labelY] = getBezierPath(props);
+
+    return (
+        <>
+            <BaseEdge id={id} path={edgePath} {...props} />
+            <EdgeLabelRenderer>
+                <Card
+                    style={{
+                        padding: 5,
+                        textAlign: "center",
+                        // required to place label exactly on the edge
+                        position: "absolute",
+                        transform: `translate(-50%, -50%) translate(${labelX}px,${labelY}px)`,
+                    }}
+                    className="nodrag nopan"
+                >
+                    {data.type ? (
+                        <Chip
+                            size="small"
+                            color="secondary"
+                            label={data.type as string}
+                            style={props.labelStyle}
+                        />
+                    ) : null}
+                    {data.num_rows && (
+                        <Typography>
+                            {formatNumberApprox(data.num_rows)} rows
+                        </Typography>
+                    )}
+                    {data.num_bytes && (
+                        <Typography>{formatBytes(data.num_bytes)}</Typography>
+                    )}
+                    {data.num_files && (
+                        <Typography>
+                            {formatNumberApprox(data.num_files)} files
+                        </Typography>
+                    )}
+                </Card>
+            </EdgeLabelRenderer>
+        </>
+    );
+};
+
+export default IOEdge;

--- a/src/components/lineage/edges/index.ts
+++ b/src/components/lineage/edges/index.ts
@@ -1,0 +1,4 @@
+import IOEdge from "./IOEdge";
+import BaseEdge from "./BaseEdge";
+
+export { IOEdge, BaseEdge };

--- a/src/components/lineage/utils/getGraphEdges.tsx
+++ b/src/components/lineage/utils/getGraphEdges.tsx
@@ -9,6 +9,9 @@ import {
 } from "@/dataProvider/types";
 import { Edge, MarkerType } from "@xyflow/react";
 import { getNodeId } from "./getGraphNodes";
+import formatBytes from "@/utils/bytes";
+import formatNumberApprox from "@/utils/numbers";
+import { Chip } from "@mui/material";
 
 const STOKE_THICK = 3;
 const STOKE_THIN = 1;
@@ -27,6 +30,7 @@ const getMinimalEdge = (
         id: getEdgeId(relation),
         source: getNodeId(relation.from),
         target: getNodeId(relation.to),
+        type: "baseEdge",
         // @ts-ignore
         data: relation,
         markerEnd: {
@@ -71,8 +75,8 @@ const getOutputEdge = (
 
     return {
         ...getMinimalEdge(relation, raw_response),
+        type: "ioEdge",
         animated: true,
-        label: relation.type,
         markerEnd: {
             type: MarkerType.ArrowClosed,
             color: color,
@@ -80,6 +84,9 @@ const getOutputEdge = (
         style: {
             strokeWidth: STOKE_THICK,
             stroke: color,
+        },
+        labelStyle: {
+            backgroundColor: color,
         },
     };
 };
@@ -91,6 +98,7 @@ const getInputEdge = (
     const color = "green";
     return {
         ...getMinimalEdge(relation, raw_response),
+        type: "ioEdge",
         animated: true,
         markerEnd: {
             type: MarkerType.ArrowClosed,
@@ -99,6 +107,9 @@ const getInputEdge = (
         style: {
             strokeWidth: STOKE_THICK,
             stroke: color,
+        },
+        labelStyle: {
+            backgroundColor: color,
         },
     };
 };
@@ -139,6 +150,8 @@ const getSymlinkEdge = (
         (r) => r.kind == "OUTPUT" || r.kind == "SYMLINK",
     );
 
+    const color = "purple";
+
     return {
         ...getMinimalEdge(relation, raw_response),
         label: "SYMLINK",
@@ -150,15 +163,18 @@ const getSymlinkEdge = (
             : getNodeId(relation.to),
         markerStart: {
             type: MarkerType.ArrowClosed,
-            color: "purple",
+            color: color,
         },
         markerEnd: {
             type: MarkerType.ArrowClosed,
-            color: "purple",
+            color: color,
         },
         style: {
             strokeWidth: STOKE_THIN,
-            stroke: "purple",
+            stroke: color,
+        },
+        labelStyle: {
+            backgroundColor: color,
         },
     };
 };

--- a/src/dataProvider/types.ts
+++ b/src/dataProvider/types.ts
@@ -97,6 +97,9 @@ interface BaseRelationLineageResponseV1 {
 
 interface InputRelationLineageResponseV1 extends BaseRelationLineageResponseV1 {
     kind: "INPUT";
+    num_rows: number | null;
+    num_bytes: number | null;
+    num_files: number | null;
 }
 
 type OutputRelationTypeLineageResponseV1 =
@@ -111,6 +114,9 @@ interface OutputRelationLineageResponseV1
     extends BaseRelationLineageResponseV1 {
     kind: "OUTPUT";
     type: OutputRelationTypeLineageResponseV1;
+    num_rows: number | null;
+    num_bytes: number | null;
+    num_files: number | null;
 }
 
 interface ParentRelationLineageResponseV1

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -1,0 +1,16 @@
+import { useTranslate } from "react-admin";
+
+const step = 1024;
+const suffixes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+
+const formatBytes = (bytes: number, decimals = 2) => {
+    const translate = useTranslate();
+    const i = Math.floor(Math.log(bytes) / Math.log(step));
+    const suffix = translate(`units.bytes.${suffixes[i]}`, { _: suffixes[i] });
+    const roundedValue = bytes / Math.pow(step, i);
+    const formattedValue =
+        roundedValue > 0 ? roundedValue.toFixed(decimals) : "0";
+    return formattedValue + suffix;
+};
+
+export default formatBytes;

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -1,0 +1,18 @@
+import { useTranslate } from "react-admin";
+
+const step = 1000;
+const suffixes = ["K", "M", "B", "T"];
+
+const formatNumberApprox = (value: number, decimals = 2): string => {
+    const translate = useTranslate();
+    if (value < step) return value.toString();
+
+    const i = Math.floor(Math.log(value) / Math.log(step));
+    const suffix = translate(`units.numbers.${suffixes[i]}`, {
+        _: suffixes[i],
+    });
+    const roundedValue = value / Math.pow(step, i);
+    return roundedValue.toFixed(decimals) + suffix;
+};
+
+export default formatNumberApprox;


### PR DESCRIPTION
Now API returns `num_rows`/`num_bytes`/`num_files` in the response, so we can show this stats on the edge.

What's changed:
* Added 2 edge types - `IOEdge` (complex label containing stats) and `BaseEdge` (just text label).
* Added formatting functions for bytes and numbers with rounding, to show value `10240 bytes` as `10KB`, and `12345` as `12K rows`, respectively.

![Снимок экрана_20241108_143252-1](https://github.com/user-attachments/assets/61dd9744-2da1-4216-ab01-9b1389d1bb22)
