### PR TITLE
[DOP-20147] Implement location edit

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import {
     LocationRaList,
     LocationRaShow,
     LocationRaRepr,
+    LocationRaEdit,
 } from "@/components/location";
 import {
     DatasetRaList,
@@ -55,6 +56,7 @@ const App = () => {
                     icon={Public}
                     list={LocationRaList}
                     show={LocationRaShow}
+                    edit={LocationRaEdit}
                     recordRepresentation={<LocationRaRepr />}
                 />
                 <Resource

--- a/src/components/location/LocationRaEdit.tsx
+++ b/src/components/location/LocationRaEdit.tsx
@@ -1,0 +1,43 @@
+import { ReactElement } from "react";
+import {
+    Edit,
+    SaveButton,
+    SimpleForm,
+    TextInput,
+    Toolbar,
+    TransformData,
+} from "react-admin";
+
+const LocationRaEditToolbar = () => {
+    return (
+        <Toolbar>
+            <SaveButton />
+            {/* Delete operation is not supportedm remove it */}
+        </Toolbar>
+    );
+};
+
+const LocationRaEdit = (): ReactElement => {
+    const transform = (data: { external_id?: string }) => ({
+        external_id: data.external_id,
+        // Other fields are not updatable, exclude from the payload
+    });
+
+    return (
+        <Edit
+            resource="locations"
+            redirect="show"
+            mutationMode="pessimistic"
+            transform={transform}
+        >
+            <SimpleForm sanitizeEmptyValues toolbar={<LocationRaEditToolbar />}>
+                <TextInput source="id" disabled />
+                <TextInput source="type" disabled />
+                <TextInput source="name" disabled />
+                <TextInput source="external_id" resettable />
+            </SimpleForm>
+        </Edit>
+    );
+};
+
+export default LocationRaEdit;

--- a/src/components/location/index.ts
+++ b/src/components/location/index.ts
@@ -4,6 +4,7 @@ import LocationType from "./LocationType";
 import LocationRaRepr from "./LocationRaRepr";
 import LocationRaList from "./LocationRaList";
 import LocationRaShow from "./LocationRaShow";
+import LocationRaEdit from "./LocationRaEdit";
 import LocationRaTypeWithIconField from "./LocationRaTypeWithIconField";
 import LocationRaNameWithLinkField from "./LocationRaNameWithLinkField";
 
@@ -14,6 +15,7 @@ export {
     LocationRaRepr,
     LocationRaList,
     LocationRaShow,
+    LocationRaEdit,
     LocationRaTypeWithIconField,
     LocationRaNameWithLinkField,
 };

--- a/src/dataProvider/index.ts
+++ b/src/dataProvider/index.ts
@@ -4,6 +4,7 @@ import {
     GetManyParams,
     GetOneParams,
     QueryFunctionContext,
+    UpdateParams,
 } from "react-admin";
 import { parseJSON, parseResponse } from "./utils";
 
@@ -51,11 +52,9 @@ const defaultDataProvider: DataProvider = {
             }
         }
 
-        const signal = params.signal;
-
         return fetch(url.toString(), {
             method: "GET",
-            signal,
+            signal: params.signal,
         })
             .then(parseResponse)
             .then(({ status, body }) => {
@@ -86,11 +85,9 @@ const defaultDataProvider: DataProvider = {
             url.searchParams.append(`${resourceOne}_id`, id.toString());
         });
 
-        const signal = params.signal;
-
         return fetch(url.toString(), {
             method: "GET",
-            signal,
+            signal: params.signal,
         })
             .then(parseResponse)
             .then(({ status, body }) => {
@@ -112,11 +109,9 @@ const defaultDataProvider: DataProvider = {
         const resourceOne = resource.slice(0, -1);
         url.searchParams.append(`${resourceOne}_id`, params.id.toString());
 
-        const signal = params.signal;
-
         return fetch(url.toString(), {
             method: "GET",
-            signal,
+            signal: params.signal,
         })
             .then(parseResponse)
             .then(({ status, body }) => {
@@ -148,17 +143,28 @@ const defaultDataProvider: DataProvider = {
             }
         }
 
-        const signal = params.signal;
-
         return fetch(url.toString(), {
             method: "GET",
-            signal,
+            signal: params.signal,
         })
             .then(parseResponse)
             .then(({ status, body }) => parseJSON(status, body));
     },
-    // @ts-ignore
-    update: () => Promise.resolve({ data: {} }),
+    update: (resource: string, params: UpdateParams) => {
+        const url = getURL(`/v1/${resource}/${params.id}`);
+
+        return fetch(url.toString(), {
+            method: "PATCH",
+            body: JSON.stringify(params.data),
+            headers: { "Content-Type": "application/json" },
+        })
+            .then(parseResponse)
+            .then(({ status, body }) => {
+                return {
+                    data: parseJSON(status, body),
+                };
+            });
+    },
     updateMany: () => Promise.resolve({}),
 };
 

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -49,7 +49,7 @@ const customEnglishMessages: TranslationMessages = {
             },
             fields: {
                 id: "Location ID",
-                type: "Location name",
+                type: "Location type",
                 name: "Location name",
                 external_id: "External ID",
             },


### PR DESCRIPTION
Implement `LocationRaEdit` component. It allows to set/reset `external_id` field of location, and sends a proper `PATCH` request to API. Other fields are currently read-only.

![Снимок экрана_20241108_164053](https://github.com/user-attachments/assets/5fc25e60-dd73-4bbb-ad5f-5c7096849686)

![Снимок экрана_20241108_164102](https://github.com/user-attachments/assets/046e4330-2912-4863-b0ea-258c617a4d53)
