### PR TITLE
[DOP-21576] Add Keycloak Auth Provider

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,9 @@ RUN chmod +x /entrypoint.sh
 
 
 ARG API_URL=http://localhost:8000
+ARG AUTH_PROVIDER=dummyAuthProvider
 ENV DATA_RENTGEN__UI__API_BROWSER_URL=${API_URL}
+ENV DATA_RENTGEN__UI__AUTH_PROVIDER=${AUTH_PROVIDER}
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["nginx", "-g", "daemon off;"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -2,6 +2,8 @@
 
 # replace api url with one specified in env variable
 sed s#http://localhost:8000#${DATA_RENTGEN__UI__API_BROWSER_URL}# -i /usr/share/nginx/html/assets/index*.js
+# replace authProvider with specified in env variable
+sed s#dummyAuthProvider#${DATA_RENTGEN__UI__AUTH_PROVIDER}# -i /usr/share/nginx/html/assets/index*.js
 
 # run original entrypoint
 exec "$@"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,13 +5,12 @@ import {
     StoreContextProvider,
     Resource,
 } from "react-admin";
-
-import authProvider from "./authProvider";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import defaultDataProvider from "./dataProvider";
 import englishMessages from "./i18n/en";
 import { Layout } from "./layout";
 import { mainLightTheme, mainDarkTheme } from "@/themes/main";
-import { Login } from "@/components/login";
+import { getAuthProvider, Callback } from "@/components/login";
 import {
     LocationRaList,
     LocationRaShow,
@@ -35,53 +34,60 @@ const i18nProvider = polyglotI18nProvider((locale) => englishMessages, "en", [
     { locale: "en", name: "English" },
 ]);
 
+const authProvider = getAuthProvider();
+
 const App = () => {
     return (
         <StoreContextProvider value={store}>
-            <Admin
-                title=""
-                dataProvider={defaultDataProvider}
-                store={store}
-                authProvider={authProvider}
-                loginPage={Login}
-                layout={Layout}
-                i18nProvider={i18nProvider}
-                disableTelemetry
-                lightTheme={mainLightTheme}
-                darkTheme={mainDarkTheme}
-                defaultTheme="light"
-                requireAuth
-            >
-                <Resource
-                    name="locations"
-                    icon={Public}
-                    list={LocationRaList}
-                    show={LocationRaShow}
-                    edit={LocationRaEdit}
-                    recordRepresentation={<LocationRaRepr />}
-                />
-                <Resource
-                    name="datasets"
-                    icon={DatasetIcon}
-                    list={DatasetRaList}
-                    show={DatasetRaShow}
-                    recordRepresentation={<DatasetRaRepr />}
-                />
-                <Resource
-                    name="jobs"
-                    icon={Settings}
-                    list={JobRaList}
-                    show={JobRaShow}
-                    recordRepresentation={<JobRaRepr />}
-                />
-                <Resource
-                    name="runs"
-                    icon={PlayArrow}
-                    list={RunRaList}
-                    show={RunRaShow}
-                />
-                <Resource name="operations" show={OperationRaShow} />
-            </Admin>
+            <BrowserRouter>
+                <Admin
+                    title=""
+                    dataProvider={defaultDataProvider}
+                    store={store}
+                    authProvider={authProvider.provider}
+                    loginPage={authProvider.loginPage}
+                    layout={Layout}
+                    i18nProvider={i18nProvider}
+                    disableTelemetry
+                    lightTheme={mainLightTheme}
+                    darkTheme={mainDarkTheme}
+                    defaultTheme="light"
+                    requireAuth
+                >
+                    <Resource
+                        name="locations"
+                        icon={Public}
+                        list={LocationRaList}
+                        show={LocationRaShow}
+                        edit={LocationRaEdit}
+                        recordRepresentation={<LocationRaRepr />}
+                    />
+                    <Resource
+                        name="datasets"
+                        icon={DatasetIcon}
+                        list={DatasetRaList}
+                        show={DatasetRaShow}
+                        recordRepresentation={<DatasetRaRepr />}
+                    />
+                    <Resource
+                        name="jobs"
+                        icon={Settings}
+                        list={JobRaList}
+                        show={JobRaShow}
+                        recordRepresentation={<JobRaRepr />}
+                    />
+                    <Resource
+                        name="runs"
+                        icon={PlayArrow}
+                        list={RunRaList}
+                        show={RunRaShow}
+                    />
+                    <Resource name="operations" show={OperationRaShow} />
+                </Admin>
+                <Routes>
+                    <Route path="/auth/callback" element={<Callback />} />
+                </Routes>
+            </BrowserRouter>
         </StoreContextProvider>
     );
 };

--- a/src/auth/dummyAuth.ts
+++ b/src/auth/dummyAuth.ts
@@ -1,0 +1,64 @@
+import { AuthProvider } from "react-admin";
+
+import { getURL } from "@/dataProvider/utils";
+
+const authProvider: AuthProvider = {
+    login: ({ username, password }) => {
+        const formdata = new FormData();
+        formdata.append("username", username);
+        formdata.append("password", password);
+
+        const requestOptions = {
+            method: "POST",
+            body: formdata,
+            redirect: "follow",
+        };
+
+        // @ts-expect-error requestOptions
+        return fetch(getURL("/v1/auth/token"), requestOptions)
+            .then((response) => {
+                if (response.status < 200 || response.status >= 300) {
+                    throw new Error(response.statusText);
+                }
+                return response.json();
+            })
+            .then((json) => json.access_token)
+            .then((token) => {
+                localStorage.setItem("token", token);
+                localStorage.setItem("username", username);
+            })
+            .catch((e) => {
+                console.error(e);
+            });
+    },
+    logout: () => {
+        localStorage.removeItem("token");
+        localStorage.removeItem("username");
+        return Promise.resolve();
+    },
+    checkError(error) {
+        const status = error.status;
+        if (status === 401) {
+            localStorage.removeItem("token");
+            throw new Error(error.statusText);
+        }
+        return Promise.resolve();
+    },
+    checkAuth: () =>
+        localStorage.getItem("username") ? Promise.resolve() : Promise.reject(),
+    getPermissions: () => Promise.resolve(),
+    getIdentity: () => {
+        const user = localStorage.getItem("username");
+        if (!user) {
+            return Promise.reject();
+        }
+        return Promise.resolve({
+            id: "user",
+            fullName: user,
+            // TODO: add avatar example
+            avatar: "./avatar.svg",
+        });
+    },
+};
+
+export default authProvider;

--- a/src/auth/keycloakAuth.ts
+++ b/src/auth/keycloakAuth.ts
@@ -1,0 +1,56 @@
+import { AuthProvider } from "react-admin";
+import { parseResponse, getURL } from "@/dataProvider/utils";
+
+const keycloakAuthProvider: AuthProvider = {
+    login: () => {
+        const requestOptions = {
+            method: "GET",
+            redirect: "follow",
+            credentials: "include",
+        };
+        // @ts-expect-error requestOptions
+        return fetch(getURL("/v1/users/me"), requestOptions)
+            .then(parseResponse)
+            .then(({ status, body }) => {
+                const json = JSON.parse(body);
+                if (status === 401 && json.error.code === "auth_redirect") {
+                    window.location.href = json.error.details;
+                }
+                if (status >= 200 && status < 300) {
+                    localStorage.setItem("username", json.name);
+                    window.location.href = "/";
+                }
+            })
+            .catch((e) => {
+                console.error(e);
+            });
+    },
+    logout: () => {
+        // TODO Change this method after adding /logout endpoint on backend
+        localStorage.removeItem("username");
+        window.location.href = "/#/login";
+        return Promise.resolve();
+    },
+    checkAuth: () =>
+        localStorage.getItem("username") ? Promise.resolve() : Promise.reject(),
+    checkError: (error) => {
+        if (error.body.error.code === "auth_redirect") {
+            window.location.href = error.body.error.details;
+        }
+        throw error;
+    },
+    getIdentity: () => {
+        const user = localStorage.getItem("username");
+        if (!user) {
+            return Promise.reject();
+        }
+        return Promise.resolve({
+            id: "user",
+            fullName: user,
+            // TODO: add avatar example
+            avatar: "./avatar.svg",
+        });
+    },
+};
+
+export { keycloakAuthProvider };

--- a/src/components/login/index.ts
+++ b/src/components/login/index.ts
@@ -1,3 +1,23 @@
 import Login from "./Login";
+import authProvider from "@/authProvider";
+import { keycloakAuthProvider } from "@/auth/keycloakAuth";
+import { keycloakLogin, Callback } from "./keycloak";
 
-export { Login };
+const AUTH_PROVIDER = "dummyAuthProvider";
+
+const getAuthProvider = () => {
+    switch (AUTH_PROVIDER) {
+        case "keycloakAuthProvider":
+            return {
+                provider: keycloakAuthProvider,
+                loginPage: keycloakLogin,
+            };
+        default:
+            return {
+                provider: authProvider,
+                loginPage: Login,
+            };
+    }
+};
+
+export { getAuthProvider, Callback };

--- a/src/components/login/keycloak/callback.tsx
+++ b/src/components/login/keycloak/callback.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+import { CircularProgress } from "@mui/material";
+
+import { getURL } from "@/dataProvider/utils";
+
+const Callback = () => {
+    const params = useLocation();
+    const url = getURL("/v1/auth/callback" + params["search"]);
+    const requestOptions = {
+        method: "GET",
+        redirect: "follow",
+        credentials: "include",
+    };
+    useEffect(() => {
+        // @ts-expect-error requestOptions
+        fetch(url.toString(), requestOptions)
+            .then((response) => {
+                if (response.status < 200 || response.status >= 300) {
+                    throw new Error(response.statusText);
+                }
+                return response.status === 200
+                    ? (window.location.href = "/")
+                    : response.json();
+            })
+            .catch((e) => {
+                console.error(e);
+            });
+    }, []);
+
+    return <CircularProgress size={25} thickness={2} />;
+};
+
+export default Callback;

--- a/src/components/login/keycloak/index.ts
+++ b/src/components/login/keycloak/index.ts
@@ -1,0 +1,4 @@
+import keycloakLogin from "./keycloak_login";
+import Callback from "./callback";
+
+export { keycloakLogin, Callback };

--- a/src/components/login/keycloak/keycloak_login.tsx
+++ b/src/components/login/keycloak/keycloak_login.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+
+import {
+    Box,
+    Button,
+    Card,
+    CardActions,
+    CircularProgress,
+    Stack,
+    Typography,
+} from "@mui/material";
+import { Form, useTranslate, useAuthProvider } from "react-admin";
+import { DataRentgenIcon } from "../../icons";
+
+const keycloakLogin = () => {
+    const [loading] = useState(false);
+    const translate = useTranslate();
+
+    const authProvider = useAuthProvider();
+    if (!authProvider) {
+        return null;
+    }
+
+    return (
+        <Form onSubmit={authProvider.login} noValidate>
+            <Box
+                sx={{
+                    display: "flex",
+                    flexDirection: "column",
+                    minHeight: "100vh",
+                    alignItems: "center",
+                    justifyContent: "flex-start",
+                    background:
+                        "url(https://source.unsplash.com/featured/1600x900)",
+                    backgroundRepeat: "no-repeat",
+                    backgroundSize: "cover",
+                }}
+            >
+                <Card sx={{ minWidth: 300, marginTop: "6em" }}>
+                    <Stack
+                        direction="column"
+                        sx={{
+                            alignItems: "center",
+                        }}
+                    >
+                        <DataRentgenIcon />
+                        <Typography variant="h5">Data.Rentgen</Typography>
+                    </Stack>
+                    <Box
+                        sx={{
+                            marginTop: "1em",
+                            display: "flex",
+                            justifyContent: "center",
+                            color: (theme) => theme.palette.grey[500],
+                        }}
+                    ></Box>
+                    <CardActions sx={{ padding: "0 1em 1em 1em" }}>
+                        <Button
+                            variant="contained"
+                            type="submit"
+                            color="primary"
+                            disabled={loading}
+                            fullWidth
+                        >
+                            {loading && (
+                                <CircularProgress size={25} thickness={2} />
+                            )}
+                            {translate("ra.auth.sign_in")}
+                        </Button>
+                    </CardActions>
+                </Card>
+            </Box>
+        </Form>
+    );
+};
+
+export default keycloakLogin;

--- a/src/dataProvider/index.ts
+++ b/src/dataProvider/index.ts
@@ -51,6 +51,7 @@ const defaultDataProvider: DataProvider = {
             method: "GET",
             signal: params.signal,
             headers: headers,
+            credentials: "include",
         })
             .then(parseResponse)
             .then(({ status, body }) => {
@@ -88,6 +89,7 @@ const defaultDataProvider: DataProvider = {
             method: "GET",
             signal: params.signal,
             headers: headers,
+            credentials: "include",
         })
             .then(parseResponse)
             .then(({ status, body }) => {
@@ -116,6 +118,7 @@ const defaultDataProvider: DataProvider = {
             method: "GET",
             signal: params.signal,
             headers: headers,
+            credentials: "include",
         })
             .then(parseResponse)
             .then(({ status, body }) => {
@@ -154,6 +157,7 @@ const defaultDataProvider: DataProvider = {
             method: "GET",
             signal: params.signal,
             headers: headers,
+            credentials: "include",
         })
             .then(parseResponse)
             .then(({ status, body }) => parseJSON(status, body));
@@ -169,6 +173,7 @@ const defaultDataProvider: DataProvider = {
             method: "PATCH",
             body: JSON.stringify(params.data),
             headers: headers,
+            credentials: "include",
         })
             .then(parseResponse)
             .then(({ status, body }) => {

--- a/src/dataProvider/utils.ts
+++ b/src/dataProvider/utils.ts
@@ -10,6 +10,7 @@ const parseResponse = (response: any) =>
 
 const parseJSON = (status: number, body: string) => {
     let json = JSON.parse(body);
+
     if (status < 200 || status >= 400) {
         throw new HttpError((json && json.message) || body, status, json);
     }


### PR DESCRIPTION
Adding keycloak auth provider.

- Switching between providers occurs through the environment variable AUTH_PROVIDER, and component getAuthProvdier
- Add route /auth/callback for handling redirect from keycloak and change code to tokens at backend
- Implemente keycloakAuthProvider(based on authProvider from RA), keycloak Login Page