### PR TITLE
[DOP-22411] Prefer output schema of dataset

### DIFF
--- a/src/dataProvider/types.ts
+++ b/src/dataProvider/types.ts
@@ -101,7 +101,7 @@ type IORelationSchemaV1 = {
 };
 
 type IORelationSchemaFieldV1 = {
-    name: string | null;
+    name: string;
     type: string | null;
     description: string | null;
     fields: IORelationSchemaFieldV1[];
@@ -109,6 +109,7 @@ type IORelationSchemaFieldV1 = {
 
 interface InputRelationLineageResponseV1 extends BaseRelationLineageResponseV1 {
     kind: "INPUT";
+    last_interaction_at: string;
     num_rows: number | null;
     num_bytes: number | null;
     num_files: number | null;
@@ -126,6 +127,7 @@ type OutputRelationTypeLineageResponseV1 =
 interface OutputRelationLineageResponseV1
     extends BaseRelationLineageResponseV1 {
     kind: "OUTPUT";
+    last_interaction_at: string;
     type: OutputRelationTypeLineageResponseV1 | null;
     num_rows: number | null;
     num_bytes: number | null;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -73,7 +73,8 @@ const customEnglishMessages: TranslationMessages = {
                     type: "Location Type",
                 },
                 schema: {
-                    name: "Projected Schema",
+                    input: "Input schema (projected) |||| Latest of %{smart_count} input schemas (projected)",
+                    output: "Output Schema |||| Latest of %{smart_count} output schemas",
                     field: {
                         name: "Field",
                         type: "Type",


### PR DESCRIPTION
Previously when we encountered dataset with multiple schemas (input, output or both), we just ignored all of them. Now prefer latest output schema (as it mostly contains the entire set of columns), and fallback to latest input schema (may contain not all columns). If there are multiple schemas, show a note for user.

![Снимок экрана_20250211_131334-1](https://github.com/user-attachments/assets/860575f6-4930-4a11-8b95-bf7f86a07176)
![Снимок экрана_20250211_131318](https://github.com/user-attachments/assets/ab40fa84-753a-45c3-9f35-8f41f50ae6e0)
![Снимок экрана_20250211_131926-1](https://github.com/user-attachments/assets/ca996760-3343-4294-b3fd-c20dd5791fdc)
