### PR TITLE
[DOP-22580] Adjust components to handle new detailed response schemas

### DIFF
--- a/src/components/base/DurationField.tsx
+++ b/src/components/base/DurationField.tsx
@@ -8,9 +8,9 @@ const DurationField = (props: FieldProps): ReactElement => {
         <FunctionField
             render={(record) => {
                 return getDurationText({
-                    created_at: record.created_at,
-                    started_at: record.started_at,
-                    ended_at: record.ended_at,
+                    created_at: record.data.created_at,
+                    started_at: record.data.started_at,
+                    ended_at: record.data.ended_at,
                 });
             }}
             {...props}

--- a/src/components/base/StatusField.tsx
+++ b/src/components/base/StatusField.tsx
@@ -1,26 +1,31 @@
+import {
+    OperationDetailedResponseV1,
+    RunDetailedResponseV1,
+} from "@/dataProvider/types";
 import { ReactElement } from "react";
 import { ChipField, ChipFieldProps, useRecordContext } from "react-admin";
 
-const StatusField = ({ ...props }: ChipFieldProps): ReactElement | null => {
-    const record = useRecordContext();
+const statusToColorMap = {
+    STARTED: "info",
+    RUNNING: "primary",
+    SUCCEEDED: "success",
+    FAILED: "error",
+    KILLED: "error",
+    UNKNOWN: "warning",
+} as const;
+
+const StatusField = ({
+    /* eslint-disable @typescript-eslint/no-unused-vars */
+    source,
+    ...props
+}: ChipFieldProps): ReactElement | null => {
+    const record = useRecordContext<
+        RunDetailedResponseV1 | OperationDetailedResponseV1
+    >();
     if (!record) return null;
 
-    switch (record.status) {
-        case "STARTED":
-            return <ChipField color="info" {...props} />;
-        case "RUNNING":
-            return <ChipField color="primary" {...props} />;
-        case "SUCCEEDED":
-            return <ChipField color="success" {...props} />;
-        case "FAILED":
-            return <ChipField color="error" {...props} />;
-        case "KILLED":
-            return <ChipField color="error" {...props} />;
-        case "UNKNOWN":
-            return <ChipField color="warning" {...props} />;
-        default:
-            return <ChipField {...props} />;
-    }
+    const color = statusToColorMap[record.data.status];
+    return <ChipField color={color} source="data.status" {...props} />;
 };
 
 export default StatusField;

--- a/src/components/dataset/DatasetRaList.tsx
+++ b/src/components/dataset/DatasetRaList.tsx
@@ -36,14 +36,20 @@ const DatasetRaList = (): ReactElement => {
         >
             <DatagridConfigurable bulkActionButtons={false}>
                 <LocationRaTypeWithIconField
-                    source="location.type"
+                    source="data.location.type"
+                    label="resources.datasets.fields.location.type"
                     sortable={false}
                 />
                 <LocationRaNameWithLinkField
-                    source="location.name"
+                    source="data.location.name"
+                    label="resources.datasets.fields.location.name"
                     sortable={false}
                 />
-                <TextField source="name" sortable={false} />
+                <TextField
+                    source="data.name"
+                    label="resources.datasets.fields.name"
+                    sortable={false}
+                />
             </DatagridConfigurable>
         </List>
     );

--- a/src/components/dataset/DatasetRaRepr.tsx
+++ b/src/components/dataset/DatasetRaRepr.tsx
@@ -2,9 +2,10 @@ import { ReactElement } from "react";
 import { Stack } from "@mui/material";
 import { LocationIcon } from "@/components/location";
 import { useRecordContext } from "react-admin";
+import { DatasetDetailedResponseV1 } from "@/dataProvider/types";
 
 const DatasetRaRepr = (): ReactElement | null => {
-    const dataset = useRecordContext();
+    const dataset = useRecordContext<DatasetDetailedResponseV1>();
     if (!dataset) return null;
 
     return (
@@ -18,8 +19,8 @@ const DatasetRaRepr = (): ReactElement | null => {
                 textDecoration: "underline",
             }}
         >
-            <LocationIcon location={dataset.location} />
-            <span>{dataset.name}</span>
+            <LocationIcon location={dataset.data.location} />
+            <span>{dataset.data.name}</span>
         </Stack>
     );
 };

--- a/src/components/dataset/DatasetRaShow.tsx
+++ b/src/components/dataset/DatasetRaShow.tsx
@@ -16,14 +16,22 @@ const DatasetRaShow = (): ReactElement => {
     return (
         <Show resource="datasets">
             <SimpleShowLayout>
-                <TextField source="id" />
-                <LocationRaTypeWithIconField source="location.type" />
-                <LocationRaNameWithLinkField source="location.name" />
+                <TextField source="data.id" label="id" />
+                <LocationRaTypeWithIconField
+                    source="data.location.type"
+                    label="location.type"
+                />
+                <LocationRaNameWithLinkField
+                    source="data.location.name"
+                    label="location.name"
+                />
 
-                <TextField source="name" />
+                <TextField source="data.name" label="name" />
                 <WithRecord
                     render={(record) =>
-                        record.format && <TextField source="format" />
+                        record.format && (
+                            <TextField source="data.format" label="format" />
+                        )
                     }
                 />
 

--- a/src/components/job/JobRaList.tsx
+++ b/src/components/job/JobRaList.tsx
@@ -32,11 +32,24 @@ const JobRaList = (): ReactElement => {
     return (
         <List actions={<ListActions />} filters={jobFilters} resource="jobs">
             <DatagridConfigurable bulkActionButtons={false}>
-                <JobRaTypeField source="type" />
-                <TextField source="name" sortable={false} />
+                <JobRaTypeField
+                    source="data.type"
+                    label="resources.jobs.fields.type"
+                />
+                <TextField
+                    source="data.name"
+                    label="resources.jobs.fields.name"
+                    sortable={false}
+                />
 
-                <LocationRaTypeWithIconField source="location.type" />
-                <LocationRaNameWithLinkField source="location.name" />
+                <LocationRaTypeWithIconField
+                    source="data.location.type"
+                    label="resources.jobs.fields.location.type"
+                />
+                <LocationRaNameWithLinkField
+                    source="data.location.name"
+                    label="resources.jobs.fields.location.name"
+                />
             </DatagridConfigurable>
         </List>
     );

--- a/src/components/job/JobRaRepr.tsx
+++ b/src/components/job/JobRaRepr.tsx
@@ -2,10 +2,10 @@ import { ReactElement } from "react";
 import { Stack } from "@mui/material";
 import { useRecordContext } from "react-admin";
 import JobIcon from "./JobIcon";
-import { JobResponseV1 } from "@/dataProvider/types";
+import { JobDetailedResponseV1 } from "@/dataProvider/types";
 
 const JobRaRepr = (): ReactElement | null => {
-    const job = useRecordContext<JobResponseV1>();
+    const job = useRecordContext<JobDetailedResponseV1>();
     if (!job) return null;
 
     return (
@@ -19,8 +19,8 @@ const JobRaRepr = (): ReactElement | null => {
                 textDecoration: "underline",
             }}
         >
-            <JobIcon job={job} />
-            <span>{job.name}</span>
+            <JobIcon job={job.data} />
+            <span>{job.data.name}</span>
         </Stack>
     );
 };

--- a/src/components/job/JobRaShow.tsx
+++ b/src/components/job/JobRaShow.tsx
@@ -20,10 +20,19 @@ const JobRaShow = (): ReactElement => {
         <Show resource="jobs">
             <SimpleShowLayout>
                 <TextField source="id" />
-                <JobRaTypeField source="type" />
+                <JobRaTypeField
+                    source="data.type"
+                    label="resources.jobs.fields.type"
+                />
 
-                <LocationRaTypeWithIconField source="location.type" />
-                <LocationRaNameWithLinkField source="location.name" />
+                <LocationRaTypeWithIconField
+                    source="data.location.type"
+                    label="resources.jobs.fields.location.type"
+                />
+                <LocationRaNameWithLinkField
+                    source="data.location.name"
+                    label="resources.jobs.fields.location.name"
+                />
 
                 <TabbedShowLayout>
                     <TabbedShowLayout.Tab label="resources.jobs.tabs.runs">

--- a/src/components/job/JobRaTypeField.tsx
+++ b/src/components/job/JobRaTypeField.tsx
@@ -1,15 +1,15 @@
 import { ReactElement } from "react";
 import { FieldProps, useRecordContext } from "react-admin";
 import JobIconWithType from "./JobIconWithType";
-import { JobResponseV1 } from "@/dataProvider/types";
+import { JobDetailedResponseV1 } from "@/dataProvider/types";
 
 /* eslint-disable @typescript-eslint/no-unused-vars */
 const JobRaTypeField = (props: FieldProps): ReactElement | null => {
-    const record = useRecordContext<JobResponseV1>();
+    const record = useRecordContext<JobDetailedResponseV1>();
     if (!record) {
         return null;
     }
-    return <JobIconWithType job={record} />;
+    return <JobIconWithType job={record.data} />;
 };
 
 export default JobRaTypeField;

--- a/src/components/location/LocationRaEdit.tsx
+++ b/src/components/location/LocationRaEdit.tsx
@@ -25,9 +25,21 @@ const LocationRaEdit = (): ReactElement => {
         >
             <SimpleForm sanitizeEmptyValues toolbar={<LocationRaEditToolbar />}>
                 <TextInput source="id" disabled />
-                <TextInput source="type" disabled />
-                <TextInput source="name" disabled />
-                <TextInput source="external_id" resettable />
+                <TextInput
+                    source="data.type"
+                    label="resources.locations.fields.type"
+                    disabled
+                />
+                <TextInput
+                    source="data.name"
+                    label="resources.locations.fields.name"
+                    disabled
+                />
+                <TextInput
+                    source="data.external_id"
+                    label="resources.locations.fields.external_id"
+                    resettable
+                />
             </SimpleForm>
         </Edit>
     );

--- a/src/components/location/LocationRaList.tsx
+++ b/src/components/location/LocationRaList.tsx
@@ -34,15 +34,27 @@ const LocationRaList = (): ReactElement => {
             resource="locations"
         >
             <DatagridConfigurable bulkActionButtons={false}>
-                <WrapperField source="type" sortable={false}>
+                <WrapperField
+                    source="data.type"
+                    label="resources.locations.fields.type"
+                    sortable={false}
+                >
                     <WithRecord
                         render={(record) => (
-                            <LocationIconWithType location={record} />
+                            <LocationIconWithType location={record.data} />
                         )}
                     />
                 </WrapperField>
-                <TextField source="name" sortable={false} />
-                <TextField source="external_id" sortable={false} />
+                <TextField
+                    source="data.name"
+                    label="resources.locations.fields.name"
+                    sortable={false}
+                />
+                <TextField
+                    source="data.external_id"
+                    label="resources.locations.fields.external_id"
+                    sortable={false}
+                />
             </DatagridConfigurable>
         </List>
     );

--- a/src/components/location/LocationRaNameWithLinkField.tsx
+++ b/src/components/location/LocationRaNameWithLinkField.tsx
@@ -18,13 +18,13 @@ const LocationRaNameWithLinkField = (
     const path = createPath({
         resource: "locations",
         type: "show",
-        id: record.location.id,
+        id: record.data.location.id,
     });
 
     return (
         <Link href={`#${path}`}>
             <Typography variant="body2" component="span">
-                {record.location.name}
+                {record.data.location.name}
             </Typography>
         </Link>
     );

--- a/src/components/location/LocationRaRepr.tsx
+++ b/src/components/location/LocationRaRepr.tsx
@@ -2,17 +2,17 @@ import { ReactElement } from "react";
 import { Stack } from "@mui/material";
 import LocationIcon from "./LocationIcon";
 import { useRecordContext } from "react-admin";
-import { LocationResponseV1 } from "@/dataProvider/types";
+import { LocationDetailedResponseV1 } from "@/dataProvider/types";
 
 const LocationRaRepr = (): ReactElement | null => {
-    const location = useRecordContext<LocationResponseV1>();
+    const location = useRecordContext<LocationDetailedResponseV1>();
     if (!location) return null;
 
     return (
         <Stack direction={"row"} spacing={1}>
-            <LocationIcon location={location} />
+            <LocationIcon location={location.data} />
             <span>
-                {location.type}://{location.name}
+                {location.data.type}://{location.data.name}
             </span>
         </Stack>
     );

--- a/src/components/location/LocationRaShow.tsx
+++ b/src/components/location/LocationRaShow.tsx
@@ -16,17 +16,29 @@ const LocationRaShow = (): ReactElement => {
         <Show resource="locations">
             <SimpleShowLayout>
                 <TextField source="id" />
-                <WrapperField source="type">
+                <WrapperField
+                    source="data.type"
+                    label="resources.locations.fields.type"
+                >
                     <WithRecord
                         render={(record) => (
-                            <LocationIconWithType location={record} />
+                            <LocationIconWithType location={record.data} />
                         )}
                     />
                 </WrapperField>
-                <TextField source="name" />
-                <TextField source="external_id" />
+                <TextField
+                    source="data.name"
+                    label="resources.locations.fields.name"
+                />
+                <TextField
+                    source="data.external_id"
+                    label="resources.locations.fields.external_id"
+                />
 
-                <ArrayField source="addresses">
+                <ArrayField
+                    source="data.addresses"
+                    label="resources.locations.fields.addresses"
+                >
                     <Datagrid bulkActionButtons={false}>
                         <UrlField source="url" target="_blank" />
                     </Datagrid>

--- a/src/components/location/LocationRaTypeWithIconField.tsx
+++ b/src/components/location/LocationRaTypeWithIconField.tsx
@@ -10,7 +10,7 @@ const LocationRaTypeWithIconField = (
     if (!record) {
         return null;
     }
-    return <LocationIconWithType location={record.location} />;
+    return <LocationIconWithType location={record.data.location} />;
 };
 
 export default LocationRaTypeWithIconField;

--- a/src/components/operation/OperationRaLineage.tsx
+++ b/src/components/operation/OperationRaLineage.tsx
@@ -2,9 +2,10 @@ import { useRecordContext } from "react-admin";
 
 import { LineageView } from "@/components/lineage";
 import { ReactFlowProvider } from "@xyflow/react";
+import { OperationDetailedResponseV1 } from "@/dataProvider/types";
 
 const OperationRaLineage = () => {
-    const record = useRecordContext();
+    const record = useRecordContext<OperationDetailedResponseV1>();
     if (!record) {
         return null;
     }
@@ -13,7 +14,7 @@ const OperationRaLineage = () => {
             <LineageView
                 resource="operations"
                 recordId={record.id}
-                defaultSince={record.created_at as Date}
+                defaultSince={new Date(record.data.created_at)}
             />
         </ReactFlowProvider>
     );

--- a/src/components/operation/OperationRaListForRun.tsx
+++ b/src/components/operation/OperationRaListForRun.tsx
@@ -31,13 +31,27 @@ const OperationRaListForRun = ({
             disableSyncWithLocation
         >
             <DatagridConfigurable bulkActionButtons={false}>
-                <DateField source="created_at" showTime={true} />
+                <DateField
+                    source="data.created_at"
+                    label="resources.operations.fields.created_at"
+                    showTime={true}
+                />
                 {/* Do not show run, as we already in RunRaShow page*/}
-                <TextField source="position" sortable={false} />
-                <TextField source="group" sortable={false} />
+                <TextField
+                    source="data.position"
+                    label="resources.operations.fields.position"
+                    sortable={false}
+                />
+                <TextField
+                    source="data.group"
+                    label="resources.operations.fields.group"
+                    sortable={false}
+                />
                 <FunctionField
                     source="description"
-                    render={(record) => record.description || record.name}
+                    render={(record) =>
+                        record.data.description || record.data.name
+                    }
                     sortable={false}
                 />
                 <StatusField source="status" sortable={false} />

--- a/src/components/operation/OperationRaShow.tsx
+++ b/src/components/operation/OperationRaShow.tsx
@@ -17,18 +17,18 @@ const OperationRaShow = (): ReactElement => {
         <Show>
             <SimpleShowLayout>
                 <TextField source="id" />
-                <TextField source="name" />
+                <TextField source="data.name" />
 
                 <Labeled label="resources.operations.sections.external">
                     <Stack direction="row" spacing={3}>
                         <Labeled label="resources.operations.sections.position">
-                            <TextField source="position" />
+                            <TextField source="data.position" />
                         </Labeled>
                         <Labeled label="resources.operations.sections.group">
-                            <TextField source="group" />
+                            <TextField source="data.group" />
                         </Labeled>
                         <Labeled label="resources.operations.sections.description">
-                            <TextField source="description" />
+                            <TextField source="data.description" />
                         </Labeled>
                     </Stack>
                 </Labeled>
@@ -36,21 +36,27 @@ const OperationRaShow = (): ReactElement => {
                 <Labeled label="resources.operations.sections.created">
                     <Stack direction="row" spacing={3}>
                         <Labeled label="resources.operations.sections.when">
-                            <DateField source="created_at" showTime={true} />
+                            <DateField
+                                source="data.created_at"
+                                showTime={true}
+                            />
                         </Labeled>
                         <Labeled label="resources.operations.sections.by_run">
-                            <ReferenceField source="run_id" reference="runs" />
+                            <ReferenceField
+                                source="data.run_id"
+                                reference="runs"
+                            />
                         </Labeled>
                     </Stack>
                 </Labeled>
 
-                <DateField source="started_at" showTime={true} />
+                <DateField source="data.started_at" showTime={true} />
 
                 <StatusField source="status" />
                 <Labeled label="resources.operations.sections.ended">
                     <Stack direction="row" spacing={3}>
                         <Labeled label="resources.operations.sections.when">
-                            <DateField source="ended_at" showTime={true} />
+                            <DateField source="data.ended_at" showTime={true} />
                         </Labeled>
                         <Labeled label="resources.operations.sections.duration">
                             <DurationField source="duration" />

--- a/src/components/run/RunRaExternalId.tsx
+++ b/src/components/run/RunRaExternalId.tsx
@@ -1,14 +1,15 @@
-import { RunResponseV1 } from "@/dataProvider/types";
+import { RunDetailedResponseV1 } from "@/dataProvider/types";
 import { Link } from "@mui/material";
 import { FieldProps, TextField, useRecordContext } from "react-admin";
 
 const RunRaExternalId = (props: FieldProps) => {
-    const record = useRecordContext<RunResponseV1>();
-    if (!record || !record.external_id) {
+    const record = useRecordContext<RunDetailedResponseV1>();
+    if (!record || !record.data.external_id) {
         return null;
     }
 
-    const log_url = record.persistent_log_url || record.running_log_url;
+    const log_url =
+        record.data.persistent_log_url || record.data.running_log_url;
 
     if (!log_url) {
         return <TextField {...props} />;
@@ -16,7 +17,7 @@ const RunRaExternalId = (props: FieldProps) => {
 
     return (
         <Link href={log_url} target="_blank">
-            {record.external_id}
+            {record.data.external_id}
         </Link>
     );
 };

--- a/src/components/run/RunRaLineage.tsx
+++ b/src/components/run/RunRaLineage.tsx
@@ -2,9 +2,10 @@ import { useRecordContext } from "react-admin";
 
 import { LineageView } from "@/components/lineage";
 import { ReactFlowProvider } from "@xyflow/react";
+import { RunDetailedResponseV1 } from "@/dataProvider/types";
 
 const RunLineage = () => {
-    const record = useRecordContext();
+    const record = useRecordContext<RunDetailedResponseV1>();
     if (!record) {
         return null;
     }
@@ -13,7 +14,7 @@ const RunLineage = () => {
             <LineageView
                 resource="runs"
                 recordId={record.id}
-                defaultSince={record.created_at as Date}
+                defaultSince={new Date(record.data.created_at)}
                 granularities={["RUN", "OPERATION"]}
             />
         </ReactFlowProvider>

--- a/src/components/run/RunRaList.tsx
+++ b/src/components/run/RunRaList.tsx
@@ -32,23 +32,30 @@ const RunRaList = (): ReactElement => {
         >
             <DatagridConfigurable bulkActionButtons={false}>
                 <DateField
-                    source="created_at"
+                    source="data.created_at"
+                    label="resources.runs.fields.created_at"
                     showTime={true}
                     sortable={false}
                 />
                 <ReferenceField
-                    source="job_id"
+                    source="data.job_id"
+                    label="resources.runs.fields.job"
                     reference="jobs"
                     sortable={false}
                 />
                 <StatusField source="status" sortable={false} />
                 <DurationField source="duration" sortable={false} />
                 <WrapperField source="started_by_user" sortable={false}>
-                    <TextField source="started_by_user.name" />
+                    <TextField source="data.started_by_user.name" />
                 </WrapperField>
-                <RunRaExternalId source="external_id" sortable={false} />
+                <RunRaExternalId
+                    source="data.external_id"
+                    label="resources.runs.fields.external_id"
+                    sortable={false}
+                />
                 <ReferenceField
-                    source="parent_run_id"
+                    source="data.parent_run_id"
+                    label="resources.runs.fields.parent_run"
                     reference="runs"
                     sortable={false}
                 />

--- a/src/components/run/RunRaListForJob.tsx
+++ b/src/components/run/RunRaListForJob.tsx
@@ -36,7 +36,8 @@ const RunRaListForJob = ({ jobId }: { jobId: number }): ReactElement => {
         >
             <DatagridConfigurable bulkActionButtons={false}>
                 <DateField
-                    source="created_at"
+                    source="data.created_at"
+                    label="resources.runs.fields.created_at"
                     showTime={true}
                     sortable={false}
                 />
@@ -44,11 +45,16 @@ const RunRaListForJob = ({ jobId }: { jobId: number }): ReactElement => {
                 <StatusField source="status" sortable={false} />
                 <DurationField source="duration" sortable={false} />
                 <WrapperField source="started_by_user" sortable={false}>
-                    <TextField source="started_by_user.name" />
+                    <TextField source="data.started_by_user.name" />
                 </WrapperField>
-                <RunRaExternalId source="external_id" sortable={false} />
+                <RunRaExternalId
+                    source="data.external_id"
+                    label="resources.runs.fields.external_id"
+                    sortable={false}
+                />
                 <ReferenceField
-                    source="parent_run_id"
+                    source="data.parent_run_id"
+                    label="resources.runs.fields.parent_run"
                     reference="runs"
                     sortable={false}
                 />

--- a/src/components/run/RunRaListForParentRun.tsx
+++ b/src/components/run/RunRaListForParentRun.tsx
@@ -42,21 +42,27 @@ const RunRaListForParentRun = ({
         >
             <DatagridConfigurable bulkActionButtons={false}>
                 <DateField
-                    source="created_at"
+                    source="data.created_at"
+                    label="resources.runs.fields.created_at"
                     showTime={true}
                     sortable={false}
                 />
                 <ReferenceField
-                    source="job_id"
+                    source="data.job_id"
+                    label="resources.runs.fields.job"
                     reference="jobs"
                     sortable={false}
                 />
                 <StatusField source="status" sortable={false} />
                 <DurationField source="duration" sortable={false} />
                 <WrapperField source="started_by_user" sortable={false}>
-                    <TextField source="started_by_user.name" />
+                    <TextField source="data.started_by_user.name" />
                 </WrapperField>
-                <RunRaExternalId source="external_id" sortable={false} />
+                <RunRaExternalId
+                    source="data.external_id"
+                    label="resources.runs.fields.external_id"
+                    sortable={false}
+                />
                 {/* Do not show parent_run, as we already in parent RunShow page*/}
             </DatagridConfigurable>
         </List>

--- a/src/components/run/RunRaShow.tsx
+++ b/src/components/run/RunRaShow.tsx
@@ -11,7 +11,6 @@ import {
     TextField,
     UrlField,
     WithRecord,
-    WrapperField,
 } from "react-admin";
 import { DurationField, StatusField } from "@/components/base";
 import { OperationRaListForRun } from "@/components/operation";
@@ -27,14 +26,20 @@ const RunRaShow = (): ReactElement => {
                 <Labeled label="resources.runs.sections.created">
                     <Stack direction="row" spacing={3}>
                         <Labeled label="resources.runs.sections.when">
-                            <DateField source="created_at" showTime={true} />
+                            <DateField
+                                source="data.created_at"
+                                showTime={true}
+                            />
                         </Labeled>
                         <Labeled label="resources.runs.sections.for_job">
-                            <ReferenceField source="job_id" reference="jobs" />
+                            <ReferenceField
+                                source="data.job_id"
+                                reference="jobs"
+                            />
                         </Labeled>
                         <Labeled label="resources.runs.sections.by_parent_run">
                             <ReferenceField
-                                source="parent_run_id"
+                                source="data.parent_run_id"
                                 reference="runs"
                             />
                         </Labeled>
@@ -44,15 +49,16 @@ const RunRaShow = (): ReactElement => {
                 <Labeled label="resources.runs.sections.started">
                     <Stack direction="row" spacing={3}>
                         <Labeled label="resources.runs.sections.when">
-                            <DateField source="started_at" showTime={true} />
+                            <DateField
+                                source="data.started_at"
+                                showTime={true}
+                            />
                         </Labeled>
                         <Labeled label="resources.runs.sections.how">
-                            <TextField source="start_reason" />
+                            <TextField source="data.start_reason" />
                         </Labeled>
                         <Labeled label="resources.runs.sections.as_user">
-                            <WrapperField source="started_by_user">
-                                <TextField source="started_by_user.name" />
-                            </WrapperField>
+                            <TextField source="data.started_by_user.name" />
                         </Labeled>
                     </Stack>
                 </Labeled>
@@ -61,10 +67,10 @@ const RunRaShow = (): ReactElement => {
                 <Labeled label="resources.runs.sections.ended">
                     <Stack direction="row" spacing={3}>
                         <Labeled label="resources.runs.sections.when">
-                            <DateField source="ended_at" showTime={true} />
+                            <DateField source="data.ended_at" showTime={true} />
                         </Labeled>
                         <Labeled label="resources.runs.sections.how">
-                            <RichTextField source="end_reason" />
+                            <RichTextField source="data.end_reason" />
                         </Labeled>
                         <Labeled label="resources.runs.sections.duration">
                             <DurationField source="duration" />
@@ -75,20 +81,20 @@ const RunRaShow = (): ReactElement => {
                 <Labeled label="resources.runs.sections.external">
                     <Stack direction="row" spacing={3}>
                         <Labeled label="resources.runs.sections.id">
-                            <TextField source="external_id" />
+                            <TextField source="data.external_id" />
                         </Labeled>
                         <Labeled label="resources.runs.sections.attempt">
-                            <TextField source="attempt" />
+                            <TextField source="data.attempt" />
                         </Labeled>
                         <Labeled label="resources.runs.sections.external_url">
                             <UrlField
-                                source="running_log_url"
+                                source="data.running_log_url"
                                 target="_blank"
                             />
                         </Labeled>
                         <Labeled label="resources.runs.sections.logs_url">
                             <UrlField
-                                source="persistent_log_url"
+                                source="data.persistent_log_url"
                                 target="_blank"
                             />
                         </Labeled>
@@ -99,7 +105,7 @@ const RunRaShow = (): ReactElement => {
                     <TabbedShowLayout.Tab label="resources.runs.tabs.operations">
                         <WithRecord
                             render={(record) => (
-                                <OperationRaListForRun run={record} />
+                                <OperationRaListForRun run={record.data} />
                             )}
                         />
                     </TabbedShowLayout.Tab>
@@ -107,7 +113,9 @@ const RunRaShow = (): ReactElement => {
                     <TabbedShowLayout.Tab label="resources.runs.tabs.child_runs">
                         <WithRecord
                             render={(record) => (
-                                <RunRaListForParentRun parentRun={record} />
+                                <RunRaListForParentRun
+                                    parentRun={record.data}
+                                />
                             )}
                         />
                     </TabbedShowLayout.Tab>

--- a/src/dataProvider/types.ts
+++ b/src/dataProvider/types.ts
@@ -10,12 +10,36 @@ interface LocationResponseV1 {
     adresses: AddressResponseV1[];
 }
 
+interface LocationDatasetStatisticsResponseV1 {
+    total_datasets: number;
+}
+
+interface LocationJobStatisticsResponseV1 {
+    total_jobs: number;
+}
+
+interface LocationStatisticsResponseV1 {
+    datasets: LocationDatasetStatisticsResponseV1;
+    jobs: LocationJobStatisticsResponseV1;
+}
+
+interface LocationDetailedResponseV1 {
+    id: string;
+    data: LocationResponseV1;
+    statistics: LocationStatisticsResponseV1;
+}
+
 interface DatasetResponseV1 extends RaRecord {
-    id: number;
+    id: string;
     type: string;
     name: string;
     location: LocationResponseV1;
     format: string | null;
+}
+
+interface DatasetDetailedResponseV1 {
+    id: string;
+    data: DatasetResponseV1;
 }
 
 type JobTypeResponseV1 =
@@ -25,10 +49,15 @@ type JobTypeResponseV1 =
     | "UNKNOWN";
 
 interface JobResponseV1 extends RaRecord {
-    id: number;
+    id: string;
     type: JobTypeResponseV1;
     name: string;
     location: LocationResponseV1;
+}
+
+interface JobDetailedResponseV1 {
+    id: string;
+    data: JobResponseV1;
 }
 
 interface UserResponseV1 extends RaRecord {
@@ -48,7 +77,7 @@ type StartReasonResponseV1 = "AUTOMATIC" | "MANUAL";
 interface RunResponseV1 extends RaRecord {
     id: string;
     created_at: string;
-    job_id: number;
+    job_id: string;
     status: StatusResponseV1;
     parent_run_id: string | null;
     started_at: string | null;
@@ -60,6 +89,29 @@ interface RunResponseV1 extends RaRecord {
     attempt: string | null;
     running_log_url: string | null;
     persistent_log_url: string | null;
+}
+
+interface IOStatisticsResponseV1 {
+    total_datasets: number;
+    total_bytes: number;
+    total_rows: number;
+    total_files: number;
+}
+
+interface RunOperationStatisticsResponseV1 {
+    total_operations: number;
+}
+
+interface RunStatisticsResponseV1 {
+    inputs: IOStatisticsResponseV1;
+    outputs: IOStatisticsResponseV1;
+    operations: RunOperationStatisticsResponseV1;
+}
+
+interface RunDetailedResponseV1 {
+    id: string;
+    data: RunResponseV1;
+    statistics: RunStatisticsResponseV1;
 }
 
 type OperationTypeResponseV1 = "BATCH" | "STREAMING";
@@ -78,11 +130,22 @@ interface OperationResponseV1 extends RaRecord {
     ended_at: string | null;
 }
 
+interface OperationStatisticsResponseV1 {
+    inputs: IOStatisticsResponseV1;
+    outputs: IOStatisticsResponseV1;
+}
+
+interface OperationDetailedResponseV1 {
+    id: string;
+    data: OperationResponseV1;
+    statistics: OperationStatisticsResponseV1;
+}
+
 type EntityTypeLineageResponseV1 = "DATASET" | "JOB" | "RUN" | "OPERATION";
 
 interface RelationEndpointLineageResponseV1 {
     kind: EntityTypeLineageResponseV1;
-    id: number | string;
+    id: string | string;
 }
 
 interface BaseRelationLineageResponseV1 {
@@ -90,10 +153,10 @@ interface BaseRelationLineageResponseV1 {
     to: RelationEndpointLineageResponseV1;
 }
 
-interface IORelationSchemaV1 {
-    id: number;
+type IORelationSchemaV1 = {
+    id: string;
     fields: IORelationSchemaFieldV1[];
-}
+};
 
 interface IORelationSchemaFieldV1 {
     name: string;
@@ -160,10 +223,22 @@ interface LineageResponseV1 {
 
 export type {
     LocationResponseV1,
+    LocationDatasetStatisticsResponseV1,
+    LocationJobStatisticsResponseV1,
+    LocationStatisticsResponseV1,
+    LocationDetailedResponseV1,
     DatasetResponseV1,
+    DatasetDetailedResponseV1,
     JobResponseV1,
+    JobDetailedResponseV1,
     RunResponseV1,
+    IOStatisticsResponseV1,
+    RunOperationStatisticsResponseV1,
+    RunStatisticsResponseV1,
+    RunDetailedResponseV1,
     OperationResponseV1,
+    OperationStatisticsResponseV1,
+    OperationDetailedResponseV1,
     UserResponseV1,
     StatusResponseV1,
     StartReasonResponseV1,

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -136,6 +136,7 @@ const customEnglishMessages: TranslationMessages = {
                 start_reason: "Start reason",
                 ended_at: "Ended at",
                 end_reason: "End reason",
+                duration: "Duration",
                 external_id: "External ID",
                 attempt: "Attempt",
                 running_log_url: "Running log URL",
@@ -194,6 +195,7 @@ const customEnglishMessages: TranslationMessages = {
                 status: "Status",
                 started_at: "Started at",
                 ended_at: "Ended at",
+                duration: "Duration",
             },
             sections: {
                 created: "Created",


### PR DESCRIPTION
API responses for list API were changed from:
```javascript
{
    "kind": "OPERATION",
    "id": ""11111111-1111-1111-1111-111111111111",
    "name": "something",
    # ...
}
```

to:
```javascript
{
    "id": ""11111111-1111-1111-1111-111111111111",
    "data": {
        "id": ""11111111-1111-1111-1111-111111111111",
        "name": "something",
        # ...
    }
}
```

To include computed fields to the response, like `statistics`. See https://github.com/MobileTeleSystems/data-rentgen/pull/158, https://github.com/MobileTeleSystems/data-rentgen/pull/159, https://github.com/MobileTeleSystems/data-rentgen/pull/160, https://github.com/MobileTeleSystems/data-rentgen/pull/161, https://github.com/MobileTeleSystems/data-rentgen/pull/162.

So I've adjusted all components to use `source="data.field"` instead of just `source="field"`.

ReactAdmin uses `source` to read object field value, and also uses is to build translation key for label (`resources.${resource}.fields.${field}`). As now rendered field label and object field name are a bit different, I've added explicit `label=...` attribute.