### PR TITLE
[DOP-23867] Adjust components to handle new lineage response schemas

### DIFF
--- a/src/components/lineage/utils/getGraphNodes.ts
+++ b/src/components/lineage/utils/getGraphNodes.ts
@@ -1,70 +1,119 @@
 import {
-    LineageNodeResponseV1,
+    DatasetResponseV1,
+    IORelationSchemaV1,
+    JobResponseV1,
     LineageResponseV1,
-    RelationEndpointLineageResponseV1,
+    OperationResponseV1,
+    RunResponseV1,
 } from "@/dataProvider/types";
 import { Node } from "@xyflow/react";
 
-export const getNodeId = (
-    node: LineageNodeResponseV1 | RelationEndpointLineageResponseV1,
-): string => {
-    return node.kind + "-" + node.id;
-};
+const getDataseNode = (
+    node: DatasetResponseV1,
+    raw_response: LineageResponseV1,
+): Node => {
+    const outputSchemas = raw_response.relations.outputs
+        .filter((output) => output.to.id == node.id && output.schema !== null)
+        // sort by last_interaction_at descending
+        .toSorted((a, b) =>
+            a.last_interaction_at < b.last_interaction_at ? 1 : -1,
+        )
+        .map((output) => output.schema)
+        .filter((schema) => schema !== null)
+        // keep unique schemas only
+        .filter(
+            (schema, index, array) =>
+                array.findIndex((item) => item.id == schema.id) == index,
+        );
 
-const getDefaultNode = (node: LineageNodeResponseV1): Node => {
-    return {
-        id: getNodeId(node),
-        type: "default",
-        position: { x: 0, y: 0 },
-        data: node,
-    };
-};
+    const inputSchemas = raw_response.relations.inputs
+        .filter((input) => input.to.id == node.id && input.schema !== null)
+        // sort by last_interaction_at descending
+        .toSorted((a, b) =>
+            a.last_interaction_at < b.last_interaction_at ? 1 : -1,
+        )
+        .map((input) => input.schema)
+        .filter((schema) => schema !== null)
+        // keep unique schemas only
+        .filter(
+            (schema, index, array) =>
+                array.findIndex((item) => item.id == schema.id) == index,
+        );
 
-const getDataseNode = (node: LineageNodeResponseV1): Node => {
-    return {
-        ...getDefaultNode(node),
-        type: "datasetNode",
-    };
-};
-
-const getJobNode = (node: LineageNodeResponseV1): Node => {
-    return {
-        ...getDefaultNode(node),
-        type: "jobNode",
-    };
-};
-
-const getRunNode = (node: LineageNodeResponseV1): Node => {
-    return {
-        ...getDefaultNode(node),
-        type: "runNode",
-    };
-};
-
-const getOperationNode = (node: LineageNodeResponseV1): Node => {
-    return {
-        ...getDefaultNode(node),
-        type: "operationNode",
-    };
-};
-
-const getGraphNode = (node: LineageNodeResponseV1): Node => {
-    switch (node.kind) {
-        case "DATASET":
-            return getDataseNode(node);
-        case "JOB":
-            return getJobNode(node);
-        case "RUN":
-            return getRunNode(node);
-        case "OPERATION":
-            return getOperationNode(node);
-        default:
-            return getDefaultNode(node);
+    // prefer output schema as there is high chance that it describes all the columns properly.
+    // read interactions may select only a subset of columns.
+    let schema: IORelationSchemaV1 | undefined = undefined;
+    let schemaFrom: string = "input";
+    let schemaCount = 0;
+    if (outputSchemas.length > 0) {
+        schema = outputSchemas.at(0);
+        schemaFrom = "output";
+        schemaCount = outputSchemas.length;
+    } else if (inputSchemas.length > 0) {
+        schema = inputSchemas.at(0);
+        schemaFrom = "input";
+        schemaCount = inputSchemas.length;
     }
+
+    return {
+        id: "DATASET-" + node.id,
+        type: "datasetNode",
+        position: { x: 0, y: 0 },
+        data: {
+            ...node,
+            kind: "DATASET",
+            schema: schema,
+            schemaFrom: schemaFrom,
+            schemaCount: schemaCount,
+        },
+    };
+};
+
+const getJobNode = (node: JobResponseV1): Node => {
+    return {
+        id: "JOB-" + node.id,
+        type: "jobNode",
+        position: { x: 0, y: 0 },
+        data: {
+            ...node,
+            kind: "JOB",
+        },
+    };
+};
+
+const getRunNode = (node: RunResponseV1): Node => {
+    return {
+        id: "RUN-" + node.id,
+        type: "runNode",
+        position: { x: 0, y: 0 },
+        data: {
+            ...node,
+            kind: "RUN",
+        },
+    };
+};
+
+const getOperationNode = (node: OperationResponseV1): Node => {
+    return {
+        id: "OPERATION-" + node.id,
+        type: "operationNode",
+        position: { x: 0, y: 0 },
+        data: {
+            ...node,
+            kind: "OPERATION",
+        },
+    };
 };
 
 const getGraphNodes = (raw_response: LineageResponseV1): Node[] => {
-    return raw_response.nodes.map((node) => getGraphNode(node));
+    return [
+        ...Object.values(raw_response.nodes.datasets).map((dataset) =>
+            getDataseNode(dataset, raw_response),
+        ),
+        ...Object.values(raw_response.nodes.jobs).map(getJobNode),
+        ...Object.values(raw_response.nodes.runs).map(getRunNode),
+        ...Object.values(raw_response.nodes.operations).map(getOperationNode),
+    ];
 };
 
 export default getGraphNodes;

--- a/src/dataProvider/types.ts
+++ b/src/dataProvider/types.ts
@@ -11,7 +11,6 @@ interface LocationResponseV1 {
 }
 
 interface DatasetResponseV1 extends RaRecord {
-    kind: "DATASET";
     id: number;
     type: string;
     name: string;
@@ -26,7 +25,6 @@ type JobTypeResponseV1 =
     | "UNKNOWN";
 
 interface JobResponseV1 extends RaRecord {
-    kind: "JOB";
     id: number;
     type: JobTypeResponseV1;
     name: string;
@@ -48,7 +46,6 @@ type StatusResponseV1 =
 type StartReasonResponseV1 = "AUTOMATIC" | "MANUAL";
 
 interface RunResponseV1 extends RaRecord {
-    kind: "RUN";
     id: string;
     created_at: string;
     job_id: number;
@@ -68,7 +65,6 @@ interface RunResponseV1 extends RaRecord {
 type OperationTypeResponseV1 = "BATCH" | "STREAMING";
 
 interface OperationResponseV1 extends RaRecord {
-    kind: "OPERATION";
     id: string;
     created_at: string;
     run_id: string;
@@ -90,25 +86,23 @@ interface RelationEndpointLineageResponseV1 {
 }
 
 interface BaseRelationLineageResponseV1 {
-    kind: string;
     from: RelationEndpointLineageResponseV1;
     to: RelationEndpointLineageResponseV1;
 }
 
-type IORelationSchemaV1 = {
+interface IORelationSchemaV1 {
     id: number;
     fields: IORelationSchemaFieldV1[];
-};
+}
 
-type IORelationSchemaFieldV1 = {
+interface IORelationSchemaFieldV1 {
     name: string;
     type: string | null;
     description: string | null;
     fields: IORelationSchemaFieldV1[];
-};
+}
 
 interface InputRelationLineageResponseV1 extends BaseRelationLineageResponseV1 {
-    kind: "INPUT";
     last_interaction_at: string;
     num_rows: number | null;
     num_bytes: number | null;
@@ -126,7 +120,6 @@ type OutputRelationTypeLineageResponseV1 =
 
 interface OutputRelationLineageResponseV1
     extends BaseRelationLineageResponseV1 {
-    kind: "OUTPUT";
     last_interaction_at: string;
     type: OutputRelationTypeLineageResponseV1 | null;
     num_rows: number | null;
@@ -135,35 +128,35 @@ interface OutputRelationLineageResponseV1
     schema: IORelationSchemaV1 | null;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 interface ParentRelationLineageResponseV1
-    extends BaseRelationLineageResponseV1 {
-    kind: "PARENT";
-}
+    extends BaseRelationLineageResponseV1 {}
 
 type SymlinkRelationTypeLineageResponseV1 = "METASTORE" | "WAREHOUSE";
 
 interface SymlinkRelationLineageResponseV1
     extends BaseRelationLineageResponseV1 {
-    kind: "SYMLINK";
     type: SymlinkRelationTypeLineageResponseV1;
 }
 
-type LineageRelationResponseV1 =
-    | InputRelationLineageResponseV1
-    | OutputRelationLineageResponseV1
-    | ParentRelationLineageResponseV1
-    | SymlinkRelationLineageResponseV1;
+interface LineageRelationsResponseV1 {
+    parents: ParentRelationLineageResponseV1[];
+    inputs: InputRelationLineageResponseV1[];
+    outputs: OutputRelationLineageResponseV1[];
+    symlinks: SymlinkRelationLineageResponseV1[];
+}
 
-type LineageNodeResponseV1 =
-    | DatasetResponseV1
-    | JobResponseV1
-    | RunResponseV1
-    | OperationResponseV1;
+interface LineageNodesResponseV1 {
+    datasets: { [id: string]: DatasetResponseV1 };
+    jobs: { [id: string]: JobResponseV1 };
+    runs: { [id: string]: RunResponseV1 };
+    operations: { [id: string]: OperationResponseV1 };
+}
 
-type LineageResponseV1 = {
-    nodes: LineageNodeResponseV1[];
-    relations: LineageRelationResponseV1[];
-};
+interface LineageResponseV1 {
+    nodes: LineageNodesResponseV1;
+    relations: LineageRelationsResponseV1;
+}
 
 export type {
     LocationResponseV1,
@@ -171,9 +164,6 @@ export type {
     JobResponseV1,
     RunResponseV1,
     OperationResponseV1,
-    LineageNodeResponseV1,
-    LineageRelationResponseV1,
-    LineageResponseV1,
     UserResponseV1,
     StatusResponseV1,
     StartReasonResponseV1,
@@ -190,4 +180,7 @@ export type {
     ParentRelationLineageResponseV1,
     SymlinkRelationLineageResponseV1,
     SymlinkRelationTypeLineageResponseV1,
+    LineageNodesResponseV1,
+    LineageRelationsResponseV1,
+    LineageResponseV1,
 };


### PR DESCRIPTION
API response for lineage API endpoint was changed from:
```javascript
{
    "relations": [
        {
            "kind": "PARENT",
            "from": {"kind": "JOB", "id": 123},
            "to": {"kind": "RUN", "id": "00000000-0000-0000-0000-000000000000"},
        },
        {
            "kind": "SYMLINK",
            "from": {"kind": "DATASET", "id": 234},
            "to": {"kind": "DATASET", "id": 999},
        },
        {
            "kind": "INPUT",
            "from": {"kind": "DATASET", "id": 234},
            "to": {"kind": "OPERATION", "id": "11111111-1111-1111-1111-111111111111"},
        },
        {
            "kind": "OUTPUT",
            "from": {"kind": "OPERATION", "id": "11111111-1111-1111-1111-111111111111"},
            "to": {"kind": "DATASET", "id": 234},
        },
    ],
    "nodes": [
        {"kind": "DATASET", "id": 123, "name": "abc"},
        {"kind": "JOB", "id": 234, "name": "cde"},
        {
            "kind": "RUN",
            "id": "00000000-0000-0000-0000-000000000000",
            "external_id": "def",
        },
        {
            "kind": "OPERATION",
            "id": "11111111-1111-1111-1111-111111111111",
            "name": "efg",
        },
    ],
}
```

to:
```javascript
{
    "relations": {
        "parents": [
            {
                "from": {
                    "kind": "JOB",
                    "id": "123"
                },
                "to": {
                    "kind": "RUN",
                    "id": "00000000-0000-0000-0000-000000000000"
                },
            },
        ],
        "symlinks": [
            {
                "from": {
                    "kind": "DATASET",
                    "id": "234"
                },
                "to": {
                    "kind": "DATASET",
                    "id": "999"
                },
            },
        ],
        "inputs": [
            {
                "from": {
                    "kind": "DATASET",
                    "id": "234"
                },
                "to": {
                    "kind": "OPERATION",
                    "id": "11111111-1111-1111-1111-111111111111",
                },
            },
        ],
        "outputs": [
            {
                "from": {
                    "kind": "OPERATION",
                    "id": "11111111-1111-1111-1111-111111111111",
                },
                "to": {
                    "kind": "DATASET",
                    "id": "234"
                },
            },
        ],
    },
    "nodes": {
        "datasets": {
            "123": {
                "id": "123",
                "name": "abc"
            },
        },
        "jobs": {
            "234": {
                "id": "234",
                "name": "cde"
            },
        },
        "runs": {
            "00000000-0000-0000-0000-000000000000": {
                "id": "00000000-0000-0000-0000-000000000000",
                "external_id": "def",
            },
        },
        "operations": {
            "11111111-1111-1111-1111-111111111111": {
                "id": "11111111-1111-1111-1111-111111111111",
                "name": "efg",
            },
        },
    },
}
```

See https://github.com/MobileTeleSystems/data-rentgen/pull/164.

Updated lineage components to be aligned with new schemas.