### PR TITLE
[DOP-22580] Show run & operation statistics

### DIFF
--- a/src/components/base/IOStatisticsField.tsx
+++ b/src/components/base/IOStatisticsField.tsx
@@ -1,0 +1,68 @@
+import { IOStatisticsResponseV1 } from "@/dataProvider/types";
+import formatBytes from "@/utils/bytes";
+import formatNumberApprox from "@/utils/numbers";
+import { Typography } from "@mui/material";
+import { ReactElement } from "react";
+import {
+    FieldProps,
+    useFieldValue,
+    useGetResourceLabel,
+    useResourceContext,
+    useTranslate,
+} from "react-admin";
+
+const formatDatasets = (datasets: number): string => {
+    const getResourceLabel = useGetResourceLabel();
+    return (
+        datasets + " " + getResourceLabel("datasets", datasets).toLowerCase()
+    );
+};
+
+const formatRows = (rows: number): string => {
+    const resource = useResourceContext();
+    const translate = useTranslate();
+    return (
+        formatNumberApprox(rows) +
+        " " +
+        translate(`resources.${resource}.fields.statistics.rows`, {
+            smart_count: rows,
+        })
+    );
+};
+
+const formatFiles = (files: number): string => {
+    const resource = useResourceContext();
+    const translate = useTranslate();
+    return (
+        formatNumberApprox(files) +
+        " " +
+        translate(`resources.${resource}.fields.statistics.files`, {
+            smart_count: files,
+        })
+    );
+};
+
+const IOStatisticsField = (props: FieldProps): ReactElement => {
+    const statistics = useFieldValue(props) as IOStatisticsResponseV1;
+    if (statistics.total_datasets == 0) {
+        return (
+            <Typography component="span" variant="body2">
+                -
+            </Typography>
+        );
+    }
+
+    return (
+        <Typography component="span" variant="body2">
+            {formatDatasets(statistics.total_datasets)}
+            {statistics.total_bytes > 0 &&
+                ", " + formatBytes(statistics.total_bytes)}
+            {statistics.total_rows > 0 &&
+                ", " + formatRows(statistics.total_rows)}
+            {statistics.total_files > 0 &&
+                ", " + formatFiles(statistics.total_files)}
+        </Typography>
+    );
+};
+
+export default IOStatisticsField;

--- a/src/components/base/index.ts
+++ b/src/components/base/index.ts
@@ -1,5 +1,6 @@
 import StatusField from "./StatusField";
 import DurationField from "./DurationField";
 import ListActions from "./ListActions";
+import IOStatisticsField from "./IOStatisticsField";
 
-export { StatusField, DurationField, ListActions };
+export { StatusField, DurationField, ListActions, IOStatisticsField };

--- a/src/components/job/JobRaShow.tsx
+++ b/src/components/job/JobRaShow.tsx
@@ -24,6 +24,10 @@ const JobRaShow = (): ReactElement => {
                     source="data.type"
                     label="resources.jobs.fields.type"
                 />
+                <TextField
+                    source="data.name"
+                    label="resources.jobs.fields.name"
+                />
 
                 <LocationRaTypeWithIconField
                     source="data.location.type"

--- a/src/components/operation/OperationRaListForRun.tsx
+++ b/src/components/operation/OperationRaListForRun.tsx
@@ -7,7 +7,12 @@ import {
     FunctionField,
 } from "react-admin";
 
-import { DurationField, StatusField, ListActions } from "@/components/base";
+import {
+    DurationField,
+    StatusField,
+    ListActions,
+    IOStatisticsField,
+} from "@/components/base";
 import { RunResponseV1 } from "@/dataProvider/types";
 import OperationRaListFilters from "./OperationRaListFilters";
 
@@ -56,6 +61,8 @@ const OperationRaListForRun = ({
                 />
                 <StatusField source="status" sortable={false} />
                 <DurationField source="duration" sortable={false} />
+                <IOStatisticsField source="statistics.inputs" />
+                <IOStatisticsField source="statistics.outputs" />
             </DatagridConfigurable>
         </List>
     );

--- a/src/components/operation/OperationRaShow.tsx
+++ b/src/components/operation/OperationRaShow.tsx
@@ -2,6 +2,7 @@ import { Stack } from "@mui/material";
 import { ReactElement } from "react";
 import {
     DateField,
+    FunctionField,
     Labeled,
     ReferenceField,
     Show,
@@ -9,8 +10,13 @@ import {
     TabbedShowLayout,
     TextField,
 } from "react-admin";
-import { DurationField, StatusField } from "@/components/base";
+import {
+    DurationField,
+    IOStatisticsField,
+    StatusField,
+} from "@/components/base";
 import OperationRaLineage from "./OperationRaLineage";
+import { OperationDetailedResponseV1 } from "@/dataProvider/types";
 
 const OperationRaShow = (): ReactElement => {
     return (
@@ -64,11 +70,30 @@ const OperationRaShow = (): ReactElement => {
                     </Stack>
                 </Labeled>
 
-                <TabbedShowLayout>
-                    <TabbedShowLayout.Tab label="resources.operations.tabs.lineage">
-                        <OperationRaLineage />
-                    </TabbedShowLayout.Tab>
-                </TabbedShowLayout>
+                <Labeled label="resources.operations.sections.statistics.name">
+                    <Stack direction="row" spacing={3}>
+                        <Labeled label="resources.operations.sections.statistics.inputs">
+                            <IOStatisticsField source="statistics.inputs" />
+                        </Labeled>
+                        <Labeled label="resources.operations.sections.statistics.outputs">
+                            <IOStatisticsField source="statistics.outputs" />
+                        </Labeled>
+                    </Stack>
+                </Labeled>
+
+                <FunctionField
+                    render={(record: OperationDetailedResponseV1) => {
+                        return record.statistics.inputs.total_datasets +
+                            record.statistics.outputs.total_datasets >
+                            0 ? (
+                            <TabbedShowLayout>
+                                <TabbedShowLayout.Tab label="resources.operations.tabs.lineage">
+                                    <OperationRaLineage />
+                                </TabbedShowLayout.Tab>
+                            </TabbedShowLayout>
+                        ) : null;
+                    }}
+                />
             </SimpleShowLayout>
         </Show>
     );

--- a/src/components/run/RunRaList.tsx
+++ b/src/components/run/RunRaList.tsx
@@ -8,7 +8,12 @@ import {
     TextField,
 } from "react-admin";
 
-import { DurationField, StatusField, ListActions } from "@/components/base";
+import {
+    DurationField,
+    StatusField,
+    ListActions,
+    IOStatisticsField,
+} from "@/components/base";
 import RunRaListFilters from "./RunRaListFilters";
 import RunRaExternalId from "./RunRaExternalId";
 
@@ -59,6 +64,12 @@ const RunRaList = (): ReactElement => {
                     reference="runs"
                     sortable={false}
                 />
+                <TextField
+                    source="statistics.operations.total_operations"
+                    label="resources.runs.fields.statistics.operations"
+                />
+                <IOStatisticsField source="statistics.inputs" />
+                <IOStatisticsField source="statistics.outputs" />
             </DatagridConfigurable>
         </List>
     );

--- a/src/components/run/RunRaListForJob.tsx
+++ b/src/components/run/RunRaListForJob.tsx
@@ -8,7 +8,12 @@ import {
     TextField,
 } from "react-admin";
 
-import { DurationField, StatusField, ListActions } from "@/components/base";
+import {
+    DurationField,
+    StatusField,
+    ListActions,
+    IOStatisticsField,
+} from "@/components/base";
 import RunRaExternalId from "./RunRaExternalId";
 import RunRaListFilters from "./RunRaListFilters";
 
@@ -58,6 +63,12 @@ const RunRaListForJob = ({ jobId }: { jobId: number }): ReactElement => {
                     reference="runs"
                     sortable={false}
                 />
+                <TextField
+                    source="statistics.operations.total_operations"
+                    label="resources.runs.fields.statistics.operations"
+                />
+                <IOStatisticsField source="statistics.inputs" />
+                <IOStatisticsField source="statistics.outputs" />
             </DatagridConfigurable>
         </List>
     );

--- a/src/components/run/RunRaListForParentRun.tsx
+++ b/src/components/run/RunRaListForParentRun.tsx
@@ -8,7 +8,12 @@ import {
     TextField,
 } from "react-admin";
 
-import { DurationField, StatusField, ListActions } from "@/components/base";
+import {
+    DurationField,
+    StatusField,
+    ListActions,
+    IOStatisticsField,
+} from "@/components/base";
 import RunRaExternalId from "./RunRaExternalId";
 import RunRaListFilters from "./RunRaListFilters";
 import { RunResponseV1 } from "@/dataProvider/types";
@@ -64,6 +69,12 @@ const RunRaListForParentRun = ({
                     sortable={false}
                 />
                 {/* Do not show parent_run, as we already in parent RunShow page*/}
+                <TextField
+                    source="statistics.operations.total_operations"
+                    label="resources.runs.fields.statistics.operations"
+                />
+                <IOStatisticsField source="statistics.inputs" />
+                <IOStatisticsField source="statistics.outputs" />
             </DatagridConfigurable>
         </List>
     );

--- a/src/components/run/RunRaShow.tsx
+++ b/src/components/run/RunRaShow.tsx
@@ -2,6 +2,8 @@ import { Stack } from "@mui/material";
 import { ReactElement } from "react";
 import {
     DateField,
+    Empty,
+    FunctionField,
     Labeled,
     ReferenceField,
     RichTextField,
@@ -12,10 +14,15 @@ import {
     UrlField,
     WithRecord,
 } from "react-admin";
-import { DurationField, StatusField } from "@/components/base";
+import {
+    DurationField,
+    IOStatisticsField,
+    StatusField,
+} from "@/components/base";
 import { OperationRaListForRun } from "@/components/operation";
 import RunRaLineage from "./RunRaLineage";
 import RunRaListForParentRun from "./RunRaListForParentRun";
+import { RunDetailedResponseV1 } from "@/dataProvider/types";
 
 const RunRaShow = (): ReactElement => {
     return (
@@ -101,12 +108,28 @@ const RunRaShow = (): ReactElement => {
                     </Stack>
                 </Labeled>
 
+                <Labeled label="resources.runs.sections.statistics.name">
+                    <Stack direction="row" spacing={3}>
+                        <Labeled label="resources.runs.sections.statistics.inputs">
+                            <IOStatisticsField source="statistics.inputs" />
+                        </Labeled>
+                        <Labeled label="resources.runs.sections.statistics.outputs">
+                            <IOStatisticsField source="statistics.outputs" />
+                        </Labeled>
+                    </Stack>
+                </Labeled>
+
                 <TabbedShowLayout>
                     <TabbedShowLayout.Tab label="resources.runs.tabs.operations">
-                        <WithRecord
-                            render={(record) => (
-                                <OperationRaListForRun run={record.data} />
-                            )}
+                        <FunctionField
+                            render={(record: RunDetailedResponseV1) =>
+                                record.statistics.operations.total_operations >
+                                0 ? (
+                                    <OperationRaListForRun run={record.data} />
+                                ) : (
+                                    <Empty resource="operations" />
+                                )
+                            }
                         />
                     </TabbedShowLayout.Tab>
 
@@ -124,7 +147,17 @@ const RunRaShow = (): ReactElement => {
                         label="resources.runs.tabs.lineage"
                         path="lineage"
                     >
-                        <RunRaLineage />
+                        <FunctionField
+                            render={(record: RunDetailedResponseV1) =>
+                                record.statistics.inputs.total_datasets +
+                                    record.statistics.outputs.total_datasets >
+                                0 ? (
+                                    <RunRaLineage />
+                                ) : (
+                                    <Empty resource="data" />
+                                )
+                            }
+                        />
                     </TabbedShowLayout.Tab>
                 </TabbedShowLayout>
             </SimpleShowLayout>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -141,6 +141,14 @@ const customEnglishMessages: TranslationMessages = {
                 attempt: "Attempt",
                 running_log_url: "Running log URL",
                 persistent_log_url: "Persistent log URL",
+                statistics: {
+                    name: "Statistics",
+                    inputs: "Total inputs",
+                    outputs: "Total outputs",
+                    operations: "Total operations",
+                    rows: "row |||| rows",
+                    files: "file |||| files",
+                },
             },
             sections: {
                 created: "Created",
@@ -157,6 +165,11 @@ const customEnglishMessages: TranslationMessages = {
                 attempt: "Attempt",
                 external_url: "External URL",
                 logs_url: "Logs URL",
+                statistics: {
+                    name: "Statistics",
+                    inputs: "Total inputs",
+                    outputs: "Total Outputs",
+                },
             },
             tabs: {
                 operations: "Operations",
@@ -196,6 +209,13 @@ const customEnglishMessages: TranslationMessages = {
                 started_at: "Started at",
                 ended_at: "Ended at",
                 duration: "Duration",
+                statistics: {
+                    name: "Statistics",
+                    inputs: "Total inputs",
+                    outputs: "Total outputs",
+                    rows: "row |||| rows",
+                    files: "file |||| files",
+                },
             },
             sections: {
                 created: "Created",
@@ -209,6 +229,11 @@ const customEnglishMessages: TranslationMessages = {
                 ended: "Ended",
                 when: "When",
                 duration: "Duration",
+                statistics: {
+                    name: "Statistics",
+                    inputs: "Total inputs",
+                    outputs: "Total Outputs",
+                },
             },
             tabs: {
                 lineage: "Lineage",

--- a/src/utils/bytes.ts
+++ b/src/utils/bytes.ts
@@ -1,17 +1,16 @@
 import { useTranslate } from "react-admin";
 
 const step = 1024;
-const suffixes = ["Bytes", "Kb", "Mb", "Gb", "Tb", "Pb", "Eb", "Zb", "Yb"];
+const suffixes = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
 
-const formatBytes = (bytes: number, decimals = 2) => {
+const formatBytes = (bytes: number, precision = 3) => {
     const translate = useTranslate();
     const i = Math.floor(Math.log(bytes) / Math.log(step));
     const suffix = suffixes[i];
     const suffixTranslation = translate(`units.bytes.${suffix}`, { _: suffix });
-    const roundedValue = bytes / Math.pow(step, i);
-    const formattedValue =
-        roundedValue > 0 ? roundedValue.toFixed(decimals) : "0";
-    return formattedValue + suffixTranslation;
+    const result = bytes / Math.pow(step, i);
+
+    return result.toPrecision(precision) + suffixTranslation;
 };
 
 export default formatBytes;

--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -3,7 +3,7 @@ import { useTranslate } from "react-admin";
 const step = 1000;
 const suffixes = ["", "K", "M", "B", "T"];
 
-const formatNumberApprox = (value: number, decimals = 2): string => {
+const formatNumberApprox = (value: number, precision = 3): string => {
     const translate = useTranslate();
     if (value < step) return value.toString();
 
@@ -13,7 +13,7 @@ const formatNumberApprox = (value: number, decimals = 2): string => {
         _: suffix,
     });
     const roundedValue = value / Math.pow(step, i);
-    return roundedValue.toFixed(decimals) + suffixTranslation;
+    return roundedValue.toPrecision(precision) + suffixTranslation;
 };
 
 export default formatNumberApprox;


### PR DESCRIPTION
* Show statistics field in List and Show pages of runs and operations:
![Снимок экрана_20250217_150514-1](https://github.com/user-attachments/assets/893b2a3c-5b13-4938-83ce-a41209170788)
![Снимок экрана_20250217_150559-2](https://github.com/user-attachments/assets/0b54d564-4cc9-47fb-9c4b-83d6766fca53)

* If there are no operations within run (Airflow Task), show empty operations list in Operations tab. Same for inputs & outputs statistics and Lineage tab.
![Снимок экрана_20250217_150745-1](https://github.com/user-attachments/assets/81a27880-46ac-4e73-bd3a-d467f796e6d1)

* If there are no inputs & outputs for operation, don't show Lineage tab at all. Unfortunately, can't do this for Run, as `FunctionField` messes up with tab name detection mechanism.
* Small change in number formatting function: instead of values `1.23`, `12.34`, `123.45` return `1.23`, `12.3`, `123` (total number of digits is always 3).
* Add missing `job.name` field to job Show page