### PR TITLE
[DOP-22412] Improve Dataset node UX

### DIFF
--- a/src/components/lineage/nodes/dataset_node/DatasetNode.tsx
+++ b/src/components/lineage/nodes/dataset_node/DatasetNode.tsx
@@ -17,7 +17,7 @@ const DatasetNode = (props: NodeProps<DatasetNode>): ReactElement => {
     let title = props.data.name;
     const subheader = `${props.data.location.type}://${props.data.location.name}`;
     if (title.includes("/")) {
-        title = ".../" + title.substring(title.lastIndexOf("/") + 1);
+        title = ".../" + title.split("/").slice(-2).join("/");
     }
 
     const createPath = useCreatePath();

--- a/src/components/lineage/nodes/dataset_node/DatasetSchemaTable.tsx
+++ b/src/components/lineage/nodes/dataset_node/DatasetSchemaTable.tsx
@@ -1,65 +1,124 @@
 import {
+    IconButton,
+    Stack,
     Table,
     TableBody,
     TableCell,
     TableHead,
+    TablePagination,
     TableRow,
+    TextField,
 } from "@mui/material";
 import { IORelationSchemaFieldV1 } from "@/dataProvider/types";
 import { useTranslate } from "react-admin";
+import { useMemo, useState } from "react";
+import { Search } from "@mui/icons-material";
+import { paginateArray } from "../../utils/pagination";
+import { fieldMatchesText, flattenFields } from "./utils";
 
 const DatasetSchemaTable = ({
     fields,
-    level = 0,
+    defaultRowsPerPage = 10,
 }: {
     fields: IORelationSchemaFieldV1[];
-    level?: number;
+    defaultRowsPerPage?: number;
 }) => {
     const translate = useTranslate();
 
+    const [page, setPage] = useState(0);
+    const [rowsPerPage, setRowsPerPage] = useState(defaultRowsPerPage);
+    const [showSearch, setShowSearch] = useState(false);
+    const [search, setSearch] = useState("");
+
+    const filteredFields = useMemo(
+        () =>
+            flattenFields(fields).filter(
+                (field) => !showSearch || fieldMatchesText(field, search),
+            ),
+        [fields, showSearch, search],
+    );
+
+    const fieldsToShow = paginateArray(filteredFields, page, rowsPerPage);
+
+    const rowsPerPageOptions = [
+        5,
+        10,
+        25,
+        50,
+        100,
+        {
+            label: translate("resources.datasets.fields.schema.pagination.all"),
+            value: -1,
+        },
+    ];
+
     return (
-        <Table>
-            <TableHead>
-                <TableRow>
-                    <TableCell>
-                        {translate(
-                            "resources.datasets.fields.schema.field.name",
+        <>
+            <Stack
+                direction="row"
+                spacing={1}
+                justifyContent={"flex-end"}
+                className="nodrag nopan"
+            >
+                {showSearch && (
+                    <TextField
+                        id="search"
+                        type="search"
+                        autoFocus={true}
+                        placeholder={translate(
+                            "resources.datasets.fields.schema.search.placeholder",
                         )}
-                    </TableCell>
-                    <TableCell>
-                        {translate(
-                            "resources.datasets.fields.schema.field.type",
-                        )}
-                    </TableCell>
-                    <TableCell>
-                        {translate(
-                            "resources.datasets.fields.schema.field.description",
-                        )}
-                    </TableCell>
-                </TableRow>
-            </TableHead>
-            <TableBody>
-                {fields.map((field) => (
-                    <>
-                        <TableRow key={`${level}.${field.name}.main`}>
-                            <TableCell>{field.name}</TableCell>
-                            <TableCell>{field.type}</TableCell>
-                            <TableCell>{field.description}</TableCell>
-                        </TableRow>
-                        {field.fields.length > 0 && (
-                            /* create nested table for nested fields */
-                            <TableRow key={`${level}.${field.name}.nested`}>
-                                <TableCell rowSpan={level + 1} />
-                                <DatasetSchemaTable
-                                    fields={field.fields}
-                                    level={level + 1}
-                                />
+                        value={search}
+                        onChange={(e) => setSearch(e.target.value)}
+                    />
+                )}
+                <IconButton
+                    aria-label={translate(
+                        "resources.datasets.fields.schema.search.name",
+                    )}
+                    onClick={() => setShowSearch(!showSearch)}
+                >
+                    <Search />
+                </IconButton>
+            </Stack>
+            <Table>
+                <TableHead>
+                    <TableRow>
+                        <TableCell>
+                            {translate(
+                                "resources.datasets.fields.schema.field.name",
+                            )}
+                        </TableCell>
+                        <TableCell>
+                            {translate(
+                                "resources.datasets.fields.schema.field.type",
+                            )}
+                        </TableCell>
+                    </TableRow>
+                </TableHead>
+                <TableBody>
+                    {fieldsToShow.map((field) => (
+                        <>
+                            <TableRow key={`${field.name}.main`}>
+                                <TableCell>{field.name}</TableCell>
+                                <TableCell>{field.type}</TableCell>
                             </TableRow>
-                        )}
-                    </>
-                ))}
-            </TableBody>
-        </Table>
+                        </>
+                    ))}
+                </TableBody>
+                <TablePagination
+                    count={filteredFields.length}
+                    page={page}
+                    rowsPerPage={rowsPerPage}
+                    rowsPerPageOptions={rowsPerPageOptions}
+                    onPageChange={(e, pageNumber) => setPage(pageNumber)}
+                    onRowsPerPageChange={(e) =>
+                        setRowsPerPage(e.target.value as unknown as number)
+                    }
+                    className="nodrag nopan"
+                />
+            </Table>
+        </>
     );
 };
 

--- a/src/components/lineage/nodes/dataset_node/utils/fieldMatchesText.ts
+++ b/src/components/lineage/nodes/dataset_node/utils/fieldMatchesText.ts
@@ -1,0 +1,12 @@
+import { IORelationSchemaFieldV1 } from "@/dataProvider/types";
+
+export const fieldMatchesText = (
+    field: IORelationSchemaFieldV1,
+    searchText: string,
+): boolean => {
+    const forSearch = searchText.toLowerCase();
+    return (
+        field.name.toLowerCase().includes(forSearch) ||
+        (field.type ?? "").toLowerCase().includes(forSearch)
+    );
+};

--- a/src/components/lineage/nodes/dataset_node/utils/flattenFields.ts
+++ b/src/components/lineage/nodes/dataset_node/utils/flattenFields.ts
@@ -1,0 +1,18 @@
+import { IORelationSchemaFieldV1 } from "@/dataProvider/types";
+
+export const flattenFields = (
+    fields: IORelationSchemaFieldV1[],
+    prefix: string = "",
+): IORelationSchemaFieldV1[] => {
+    let result: IORelationSchemaFieldV1[] = [];
+    for (const field of fields) {
+        result.push(field);
+        if (field.fields.length > 0) {
+            // parent.child
+            result = result.concat(
+                flattenFields(field.fields, prefix + field.name + "."),
+            );
+        }
+    }
+    return result;
+};

--- a/src/components/lineage/nodes/dataset_node/utils/index.ts
+++ b/src/components/lineage/nodes/dataset_node/utils/index.ts
@@ -1,0 +1,4 @@
+import { fieldMatchesText } from "./fieldMatchesText";
+import { flattenFields } from "./flattenFields";
+
+export { fieldMatchesText, flattenFields };

--- a/src/components/lineage/utils/pagination.ts
+++ b/src/components/lineage/utils/pagination.ts
@@ -1,0 +1,9 @@
+export const paginateArray = <T>(
+    array: T[],
+    page: number,
+    rowsPerPage: number,
+): T[] => {
+    return rowsPerPage > 0
+        ? array.slice(page * rowsPerPage, (page + 1) * rowsPerPage)
+        : array;
+};

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -80,6 +80,13 @@ const customEnglishMessages: TranslationMessages = {
                         type: "Type",
                         description: "Description",
                     },
+                    search: {
+                        name: "Search",
+                        placeholder: "Filter by name",
+                    },
+                    pagination: {
+                        all: "All",
+                    },
                 },
             },
             tabs: {


### PR DESCRIPTION
Before:
![Снимок экрана_20250224_135233-1](https://github.com/user-attachments/assets/674ac31a-126a-44d4-9f63-7c5e236f0dac)

After:

- Drop `description` field as it could be very long

- List of fields is paginated with 10 items per page by default:
![Снимок экрана_20250224_141423-1](https://github.com/user-attachments/assets/a57a373e-e2e7-4d56-8767-57e102982ad3)
![Снимок экрана_20250224_141443-1](https://github.com/user-attachments/assets/1003b7bf-2723-4b3a-bc3e-24f3b04cb020)
  User may change the page size, or to show all fields without the limit.

- Added a search text field which shows only fields with name or type matching user input:
![Снимок экрана_20250224_141351-1](https://github.com/user-attachments/assets/84e01eeb-c273-423b-9ce6-02654f0ae053)
  Filter is applied on UI side, not backend.

- If node represents file path like `hdfs://cluster/app/warehouse/hive/somedb.db/sometable`, use title `.../somedb.db/sometable` instead of `.../sometable`, as database name is very important.
