### PR TITLE
[DOP-23920] Add column lineage edges

### DIFF
--- a/src/components/lineage/converters/getGraphNodes.ts
+++ b/src/components/lineage/converters/getGraphNodes.ts
@@ -5,11 +5,21 @@ import {
     LineageResponseV1,
     RunResponseV1,
 } from "@/dataProvider/types";
-import { Node } from "@xyflow/react";
+import { Node, Position } from "@xyflow/react";
 
 const BASE_NODE_HEIGHT = 120;
 const BASE_NODE_WIDTH = 800;
 const BASE_NODE_WIDTH_PER_CHAR = 25;
+
+const getDefaultNode = () => {
+    return {
+        position: { x: 0, y: 0 },
+        sourcePosition: Position.Right,
+        targetPosition: Position.Left,
+        initialWidth: BASE_NODE_WIDTH,
+        initialHeight: BASE_NODE_HEIGHT,
+    };
+};
 
 const getDataseNode = (
     node: DatasetResponseV1,
@@ -59,11 +69,9 @@ const getDataseNode = (
     }
 
     return {
+        ...getDefaultNode(),
         id: "DATASET-" + node.id,
         type: "datasetNode",
-        position: { x: 0, y: 0 },
-        initialWidth: BASE_NODE_WIDTH,
-        initialHeight: BASE_NODE_HEIGHT,
         data: {
             ...node,
             kind: "DATASET",
@@ -109,9 +117,9 @@ const getJobNode = (
         .toSorted((a, b) => (a.created_at < b.created_at ? 1 : -1));
 
     return {
+        ...getDefaultNode(),
         id: "JOB-" + node.id,
         type: "jobNode",
-        position: { x: 0, y: 0 },
         initialWidth: maxNameWidth * BASE_NODE_WIDTH_PER_CHAR,
         initialHeight: Math.min(runs.length + 1, 10) * BASE_NODE_HEIGHT,
         data: {

--- a/src/components/lineage/layout/buildLineageLayout.ts
+++ b/src/components/lineage/layout/buildLineageLayout.ts
@@ -19,11 +19,18 @@ const buildLineageLayout = ({
         nodesep: NODE_SEPARATOR,
     });
 
+    const connectedWithEdges = new Set(
+        edges.flatMap((edge) => [edge.source, edge.target]),
+    );
+
     nodes.forEach((node) => {
-        dagreGraph.setNode(node.id, {
-            width: node.measured?.width ?? node.width ?? node.initialWidth,
-            height: node.measured?.height ?? node.height ?? node.initialHeight,
-        });
+        if (connectedWithEdges.has(node.id)) {
+            dagreGraph.setNode(node.id, {
+                width: node.measured?.width ?? node.width ?? node.initialWidth,
+                height:
+                    node.measured?.height ?? node.height ?? node.initialHeight,
+            });
+        }
     });
 
     edges.forEach((edge) => {
@@ -34,6 +41,10 @@ const buildLineageLayout = ({
 
     const newNodes = nodes.map((node) => {
         const nodeWithPosition = dagreGraph.node(node.id);
+        if (!nodeWithPosition) {
+            return node;
+        }
+
         return {
             ...(node as Node),
             // We are shifting the dagre node position (anchor=center center) to the top left

--- a/src/components/lineage/nodes/dataset_node/DatasetNode.css
+++ b/src/components/lineage/nodes/dataset_node/DatasetNode.css
@@ -1,0 +1,3 @@
+.react-flow__node .hidden {
+    display: none;
+}

--- a/src/components/lineage/nodes/dataset_node/DatasetNode.tsx
+++ b/src/components/lineage/nodes/dataset_node/DatasetNode.tsx
@@ -3,6 +3,7 @@ import { useCreatePath, useTranslate } from "react-admin";
 import { memo, ReactElement } from "react";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 
+import "./DatasetNode.css";
 import { DatasetResponseV1 } from "@/dataProvider/types";
 import { LocationIconWithType } from "@/components/location";
 import { Button, CardHeader, Typography } from "@mui/material";
@@ -48,7 +49,7 @@ const DatasetNode = (props: NodeProps<DatasetNode>): ReactElement => {
                 />
             }
             expandableContent={
-                props.data && props.data.schema ? (
+                props.data.schema ? (
                     <>
                         <Typography sx={{ textAlign: "center" }}>
                             {translate(

--- a/src/components/lineage/nodes/dataset_node/DatasetSchemaTable.tsx
+++ b/src/components/lineage/nodes/dataset_node/DatasetSchemaTable.tsx
@@ -9,10 +9,11 @@ import {
     TableRow,
     TextField,
 } from "@mui/material";
-import { IORelationSchemaFieldV1 } from "@/dataProvider/types";
 import { useTranslate } from "react-admin";
+import { Handle, Position } from "@xyflow/react";
 import { useMemo, useState } from "react";
 import { Search } from "@mui/icons-material";
+import { IORelationSchemaFieldV1 } from "@/dataProvider/types";
 import { paginateArray } from "../../utils/pagination";
 import { fieldMatchesText, flattenFields } from "./utils";
 
@@ -84,6 +85,7 @@ const DatasetSchemaTable = ({
             <Table>
                 <TableHead>
                     <TableRow>
+                        <TableCell className="hidden" />
                         <TableCell>
                             {translate(
                                 "resources.datasets.fields.schema.field.name",
@@ -94,16 +96,31 @@ const DatasetSchemaTable = ({
                                 "resources.datasets.fields.schema.field.type",
                             )}
                         </TableCell>
+                        <TableCell className="hidden" />
                     </TableRow>
                 </TableHead>
                 <TableBody>
                     {fieldsToShow.map((field) => (
-                        <>
-                            <TableRow key={`${field.name}.main`}>
-                                <TableCell>{field.name}</TableCell>
-                                <TableCell>{field.type}</TableCell>
-                            </TableRow>
-                        </>
+                        <TableRow key={field.name}>
+                            <TableCell className="hidden">
+                                <Handle
+                                    type="target"
+                                    id={`field:${field.name}`}
+                                    position={Position.Left}
+                                    isConnectable={false}
+                                />
+                            </TableCell>
+                            <TableCell>{field.name}</TableCell>
+                            <TableCell>{field.type}</TableCell>
+                            <TableCell className="hidden">
+                                <Handle
+                                    type="source"
+                                    id={`field:${field.name}`}
+                                    position={Position.Right}
+                                    isConnectable={false}
+                                />
+                            </TableCell>
+                        </TableRow>
                     ))}
                 </TableBody>
                 <TablePagination

--- a/src/components/lineage/nodes/dataset_node/utils/flattenFields.ts
+++ b/src/components/lineage/nodes/dataset_node/utils/flattenFields.ts
@@ -6,7 +6,12 @@ export const flattenFields = (
 ): IORelationSchemaFieldV1[] => {
     let result: IORelationSchemaFieldV1[] = [];
     for (const field of fields) {
-        result.push(field);
+        const newField = {
+            ...field,
+            name: prefix + field.name,
+        };
+        result.push(newField);
+
         if (field.fields.length > 0) {
             // parent.child
             result = result.concat(

--- a/src/dataProvider/types.ts
+++ b/src/dataProvider/types.ts
@@ -197,6 +197,21 @@ interface ParentRelationLineageResponseV1
 
 type SymlinkRelationTypeLineageResponseV1 = "METASTORE" | "WAREHOUSE";
 
+interface ColumnLineageFieldResponseV1 {
+    name: string;
+    types: string[];
+}
+
+interface DirectColumnLineageRelationLineageResponseV1
+    extends BaseRelationLineageResponseV1 {
+    fields: { [target_field: string]: ColumnLineageFieldResponseV1[] };
+}
+
+interface IndirectColumnLineageRelationLineageResponseV1
+    extends BaseRelationLineageResponseV1 {
+    fields: ColumnLineageFieldResponseV1[];
+}
+
 interface SymlinkRelationLineageResponseV1
     extends BaseRelationLineageResponseV1 {
     type: SymlinkRelationTypeLineageResponseV1;
@@ -207,6 +222,9 @@ interface LineageRelationsResponseV1 {
     inputs: InputRelationLineageResponseV1[];
     outputs: OutputRelationLineageResponseV1[];
     symlinks: SymlinkRelationLineageResponseV1[];
+    // TODO: remove undefined after implementing these fields in backend API
+    direct_column_lineage?: DirectColumnLineageRelationLineageResponseV1[];
+    indirect_column_lineage?: IndirectColumnLineageRelationLineageResponseV1[];
 }
 
 interface LineageNodesResponseV1 {
@@ -258,4 +276,7 @@ export type {
     LineageNodesResponseV1,
     LineageRelationsResponseV1,
     LineageResponseV1,
+    ColumnLineageFieldResponseV1,
+    DirectColumnLineageRelationLineageResponseV1,
+    IndirectColumnLineageRelationLineageResponseV1,
 };


### PR DESCRIPTION
Added edges for column lineage:
![Снимок экрана_20250224_162546-1](https://github.com/user-attachments/assets/b71412d5-d79c-4b42-9f5c-d6871cca8780)

This is implemented by adding a Handler for each column in Dataset schema, and by connecting matching source+target column handlers with each other. Handlers are invisible.

Adjusted graph layout function to handle edges which are connected to virtual nodes.