### PR TITLE
[DOP-23921] Use node width and height for calculating layout

### DIFF
--- a/src/components/lineage/nodes/dataset_node/DatasetNode.tsx
+++ b/src/components/lineage/nodes/dataset_node/DatasetNode.tsx
@@ -15,12 +15,6 @@ export type DatasetNode = Node<DatasetResponseV1, "datasetNode">;
 const DatasetNode = (props: NodeProps<DatasetNode>): ReactElement => {
     const translate = useTranslate();
 
-    let title = props.data.name;
-    const subheader = `${props.data.location.type}://${props.data.location.name}`;
-    if (title.includes("/")) {
-        title = ".../" + title.split("/").slice(-2).join("/");
-    }
-
     const createPath = useCreatePath();
     const path = createPath({
         resource: "datasets",
@@ -39,8 +33,8 @@ const DatasetNode = (props: NodeProps<DatasetNode>): ReactElement => {
             }
             header={
                 <CardHeader
-                    title={title}
-                    subheader={subheader}
+                    title={props.data.title}
+                    subheader={props.data.subheader}
                     action={
                         <Button size="small" href={"#" + path}>
                             <OpenInNewIcon />

--- a/src/components/lineage/nodes/job_node/JobNode.tsx
+++ b/src/components/lineage/nodes/job_node/JobNode.tsx
@@ -14,16 +14,6 @@ export type JobNode = Node<JobResponseV1, "jobNode">;
 const JobNode = (props: NodeProps<JobNode>): ReactElement => {
     const translate = useTranslate();
 
-    let title = props.data.name;
-    let subheader = `${props.data.location.type}://${props.data.location.name}`;
-    if (props.data.name.includes("/")) {
-        title = props.data.name.substring(props.data.name.lastIndexOf("/") + 1);
-        subheader +=
-            "/" +
-            props.data.name.substring(0, props.data.name.lastIndexOf("/")) +
-            "/";
-    }
-
     const createPath = useCreatePath();
     const path = createPath({
         resource: "jobs",
@@ -42,8 +32,8 @@ const JobNode = (props: NodeProps<JobNode>): ReactElement => {
             }
             header={
                 <CardHeader
-                    title={title}
-                    subheader={subheader}
+                    title={props.data.title}
+                    subheader={props.data.subheader}
                     action={
                         <Button size="small" href={"#" + path}>
                             <OpenInNewIcon />


### PR DESCRIPTION
Title & subheader of DatasetNode and JobNode are now filled up in lineage layout helper functions instead of component render function. This allows to use proper node width and height for calculating graph layout