### PR TITLE
[DOP-23923] Add 'Column lineage' checkbox to LineageFilters

### DIFF
--- a/src/components/lineage/LineageFilters.tsx
+++ b/src/components/lineage/LineageFilters.tsx
@@ -5,6 +5,7 @@ import {
     SelectInput,
     useListParams,
     useResourceContext,
+    BooleanInput,
 } from "react-admin";
 
 import { useForm, FormProvider } from "react-hook-form";
@@ -24,6 +25,7 @@ type LineageFilterValues = {
     depth?: number;
     direction?: string;
     granularity?: string;
+    include_column_lineage?: boolean;
 };
 
 type LineageFiltersProps = {
@@ -162,6 +164,14 @@ const LineageFilters = ({
                             />
                         </Box>
                     )}
+                    <Box component="span" mr={2}>
+                        <BooleanInput
+                            source="include_column_lineage"
+                            defaultValue={false}
+                            label="lineage.filters.include_column_lineage.label"
+                            helperText="lineage.filters.include_column_lineage.helperText"
+                        />
+                    </Box>
 
                     <Box component="span" mr={2} mb={4}>
                         <Button

--- a/src/components/lineage/LineageView.tsx
+++ b/src/components/lineage/LineageView.tsx
@@ -33,6 +33,7 @@ const LineageView = (props: LineageViewProps) => {
         depth?: number;
         direction?: string;
         granularity?: string;
+        include_column_lineage?: boolean;
     }) => {
         setNodes([]);
         setNodes([]);
@@ -44,8 +45,8 @@ const LineageView = (props: LineageViewProps) => {
                     filter: values,
                 })
                 .then((data: LineageResponseV1) => {
-                    const initialNodes = getGraphNodes(data);
-                    const initialEdges = getGraphEdges(data);
+                    let initialNodes = getGraphNodes(data);
+                    let initialEdges = getGraphEdges(data);
 
                     initialNodes
                         .filter((node) => node.id == currentNodeId)

--- a/src/components/lineage/nodes/dataset_node/DatasetNode.tsx
+++ b/src/components/lineage/nodes/dataset_node/DatasetNode.tsx
@@ -42,6 +42,7 @@ const DatasetNode = (props: NodeProps<DatasetNode>): ReactElement => {
                     }
                 />
             }
+            defaultExpanded={props.data.expanded}
             expandableContent={
                 props.data.schema ? (
                     <>

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -293,6 +293,10 @@ const customEnglishMessages: TranslationMessages = {
                 run: "Run",
                 operation: "Operation",
             },
+            include_column_lineage: {
+                label: "Column lineage",
+                helperText: "Draw lineage between columns",
+            },
         },
         build_button: "Build lineage graph",
     },


### PR DESCRIPTION
Depends on adding new query param to lineage API in https://github.com/MobileTeleSystems/data-rentgen/pull/172.

With column lineage disabled (default):
![Снимок экрана_20250303_123808-1](https://github.com/user-attachments/assets/7aa23b93-6b3e-43ba-90bb-a36f9c0a2824)

With column lineage enabled:
![Снимок экрана_20250303_123901-2](https://github.com/user-attachments/assets/8775ac97-05ff-4692-8d2f-50551c870df0)

DatasetNode height depends on number of fields in schema and if node has any column lineage. If column lineage is disabled or dataset columns are not related to any other dataset columns, then DatasetNode is compacted by default. User still may expand dataset schema, if required.
