### PR TITLE
[DOP-24369] Make search_query filter optional in RunRaList

### DIFF
--- a/src/components/operation/OperationRaListFilters.tsx
+++ b/src/components/operation/OperationRaListFilters.tsx
@@ -3,21 +3,34 @@ import { required, DateTimeInput, useTranslate } from "react-admin";
 import { useForm, FormProvider } from "react-hook-form";
 import { Box, Button } from "@mui/material";
 import { useListContext } from "react-admin";
+import { useEffect } from "react";
+
+type OperationRaListFilterValues = {
+    since?: string;
+    until?: string;
+};
 
 const OperationRaListFilters = () => {
     const translate = useTranslate();
     const { filterValues, setFilters } = useListContext();
     const form = useForm({ defaultValues: filterValues });
 
-    const onSubmit = (values: { since?: string; until?: string }) => {
-        if (Object.keys(values).length > 0) {
-            setFilters(values);
-        }
-    };
+    const submit = form.handleSubmit(
+        (formValues: OperationRaListFilterValues) => {
+            if (Object.keys(formValues).length > 0) {
+                setFilters(formValues);
+            }
+        },
+    );
+
+    // fill up filters just after opening the page
+    useEffect(() => {
+        submit();
+    }, []);
 
     return (
         <FormProvider {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)}>
+            <form onSubmit={submit}>
                 <Box display="flex" alignItems="flex-end">
                     <Box component="span" mr={2}>
                         <DateTimeInput

--- a/src/components/run/RunRaList.tsx
+++ b/src/components/run/RunRaList.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useState } from "react";
+import { ReactElement } from "react";
 import {
     List,
     DatagridConfigurable,
@@ -18,22 +18,14 @@ import RunRaListFilters from "./RunRaListFilters";
 import RunRaExternalId from "./RunRaExternalId";
 
 const RunRaList = (): ReactElement => {
-    // Hack to avoid sending any network requests until user passed all required filters
-    // See https://github.com/marmelab/react-admin/issues/10286
-    const [enabled, setEnabled] = useState(false);
-
     return (
         <List
             resource="runs"
             actions={
                 <ListActions>
-                    <RunRaListFilters
-                        isReadyCallback={setEnabled}
-                        requiredFilters={["since", "search_query"]}
-                    />
+                    <RunRaListFilters />
                 </ListActions>
             }
-            queryOptions={{ enabled }}
             storeKey={false}
         >
             <DatagridConfigurable bulkActionButtons={false}>

--- a/src/components/run/RunRaListFilters.tsx
+++ b/src/components/run/RunRaListFilters.tsx
@@ -4,6 +4,7 @@ import { useForm, FormProvider } from "react-hook-form";
 import { Box, Button, InputAdornment } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
 import { TextInput, useListContext } from "react-admin";
+import { useEffect } from "react";
 
 const weekAgo = (): Date => {
     const result = new Date();
@@ -12,46 +13,36 @@ const weekAgo = (): Date => {
     return result;
 };
 
-type RunRaListFiltersProps = {
-    isReadyCallback: (enabled: boolean) => void;
-    requiredFilters: string[];
+type RunRaListFilterValues = {
+    since?: string;
+    until?: string;
+    search_query?: string;
 };
 
-const RunRaListFilters = ({
-    isReadyCallback,
-    requiredFilters = ["since", "search_query"],
-}: RunRaListFiltersProps) => {
+const RunRaListFilters = () => {
     const translate = useTranslate();
     const { filterValues, setFilters } = useListContext();
     const form = useForm({ defaultValues: filterValues });
 
-    const requiredFieldsFilled = requiredFilters.every(
-        (filter) => !!filterValues[filter],
-    );
-
-    isReadyCallback(requiredFieldsFilled);
-
-    const initialValidators = (field: string) =>
-        requiredFilters.includes(field) ? [required()] : [];
-
-    const onSubmit = (values: {
-        since?: string;
-        until?: string;
-        search_query?: string;
-    }) => {
-        if (Object.keys(values).length > 0) {
-            setFilters(values);
+    const submit = form.handleSubmit((formValues: RunRaListFilterValues) => {
+        if (Object.keys(formValues).length > 0) {
+            setFilters(formValues);
         }
-    };
+    });
+
+    // fill up filters just after opening the page
+    useEffect(() => {
+        submit();
+    }, []);
 
     return (
         <FormProvider {...form}>
-            <form onSubmit={form.handleSubmit(onSubmit)}>
+            <form onSubmit={submit}>
                 <Box display="flex" alignItems="flex-end">
                     <Box component="span" mr={2}>
                         <DateTimeInput
                             source="since"
-                            validate={initialValidators("since")}
+                            validate={required()}
                             defaultValue={weekAgo()}
                             label="resources.runs.filters.since.label"
                             helperText="resources.runs.filters.since.helperText"
@@ -61,7 +52,6 @@ const RunRaListFilters = ({
                     <Box component="span" mr={2}>
                         <DateTimeInput
                             source="until"
-                            validate={initialValidators("until")}
                             label="resources.runs.filters.until.label"
                             helperText="resources.runs.filters.until.helperText"
                         />
@@ -78,10 +68,7 @@ const RunRaListFilters = ({
                                     </InputAdornment>
                                 ),
                             }}
-                            validate={[
-                                minLength(3),
-                                ...initialValidators("search_query"),
-                            ]}
+                            validate={minLength(3)}
                             label="resources.runs.filters.search_query.label"
                             helperText="resources.runs.filters.search_query.helperText"
                         />

--- a/src/components/run/RunRaListForJob.tsx
+++ b/src/components/run/RunRaListForJob.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useState } from "react";
+import { ReactElement } from "react";
 import {
     List,
     DatagridConfigurable,
@@ -18,23 +18,15 @@ import RunRaExternalId from "./RunRaExternalId";
 import RunRaListFilters from "./RunRaListFilters";
 
 const RunRaListForJob = ({ jobId }: { jobId: number }): ReactElement => {
-    // Hack to avoid sending any network requests until user passed all required filters
-    // See https://github.com/marmelab/react-admin/issues/10286
-    const [enabled, setEnabled] = useState(false);
-
     return (
         <List
             resource="runs"
             filter={{ job_id: jobId }}
             actions={
                 <ListActions>
-                    <RunRaListFilters
-                        isReadyCallback={setEnabled}
-                        requiredFilters={["since"]}
-                    />
+                    <RunRaListFilters />
                 </ListActions>
             }
-            queryOptions={{ enabled }}
             title={false}
             storeKey={false}
         >

--- a/src/components/run/RunRaListForParentRun.tsx
+++ b/src/components/run/RunRaListForParentRun.tsx
@@ -1,4 +1,4 @@
-import { ReactElement, useState } from "react";
+import { ReactElement } from "react";
 import {
     List,
     DatagridConfigurable,
@@ -23,10 +23,6 @@ const RunRaListForParentRun = ({
 }: {
     parentRun: RunResponseV1;
 }): ReactElement => {
-    // Hack to avoid sending any network requests until user passed all required filters
-    // See https://github.com/marmelab/react-admin/issues/10286
-    const [enabled, setEnabled] = useState(false);
-
     return (
         <List
             resource="runs"
@@ -34,13 +30,9 @@ const RunRaListForParentRun = ({
             filterDefaultValues={{ since: parentRun.created_at }}
             actions={
                 <ListActions>
-                    <RunRaListFilters
-                        isReadyCallback={setEnabled}
-                        requiredFilters={["since"]}
-                    />
+                    <RunRaListFilters />
                 </ListActions>
             }
-            queryOptions={{ enabled }}
             title={false}
             storeKey={false}
         >


### PR DESCRIPTION
Depends on https://github.com/MobileTeleSystems/data-rentgen/pull/184.

Now `search_query` filter in `RunRaList` is optional, and there is no need to make additional check if user entered something here before sending request to backend.