### PR TITLE
[DOP-23712] Use schema.relevance_type field

### DIFF
--- a/src/components/lineage/converters/getGraphNodes.ts
+++ b/src/components/lineage/converters/getGraphNodes.ts
@@ -63,15 +63,18 @@ const getDataseNode = (
     // read interactions may select only a subset of columns.
     let schema: IORelationSchemaV1 | undefined = undefined;
     let schemaFrom: string = "output";
-    let schemaCount = 0;
     if (outputSchemas.length > 0) {
         schema = outputSchemas[0];
         schemaFrom = "output";
-        schemaCount = outputSchemas.length;
+        if (outputSchemas.length > 1) {
+            schema.relevance_type = "LATEST_KNOWN";
+        }
     } else if (inputSchemas.length > 0) {
         schema = inputSchemas[0];
         schemaFrom = "input";
-        schemaCount = inputSchemas.length;
+        if (inputSchemas.length > 1) {
+            schema.relevance_type = "LATEST_KNOWN";
+        }
     }
 
     let hasColumnLineage = false;
@@ -112,7 +115,6 @@ const getDataseNode = (
             expanded: hasColumnLineage,
             schema: schema,
             schemaFrom: schemaFrom,
-            schemaCount: schemaCount,
         },
     };
 };

--- a/src/components/lineage/nodes/dataset_node/DatasetNode.tsx
+++ b/src/components/lineage/nodes/dataset_node/DatasetNode.tsx
@@ -48,8 +48,7 @@ const DatasetNode = (props: NodeProps<DatasetNode>): ReactElement => {
                     <>
                         <Typography sx={{ textAlign: "center" }}>
                             {translate(
-                                `resources.datasets.fields.schema.${props.data.schemaFrom}`,
-                                { smart_count: props.data.schemaCount },
+                                `resources.datasets.fields.schema.${props.data.schemaFrom}.${props.data.schema.relevance_type.toLowerCase()}`,
                             )}
                         </Typography>
                         <DatasetSchemaTable

--- a/src/dataProvider/types.ts
+++ b/src/dataProvider/types.ts
@@ -153,9 +153,12 @@ interface BaseRelationLineageResponseV1 {
     to: RelationEndpointLineageResponseV1;
 }
 
+type IORelationSchemaRelevanceTypeV1 = "EXACT_MATCH" | "LATEST_KNOWN";
+
 type IORelationSchemaV1 = {
     id: string;
     fields: IORelationSchemaFieldV1[];
+    relevance_type: IORelationSchemaRelevanceTypeV1;
 };
 
 interface IORelationSchemaFieldV1 {
@@ -267,6 +270,7 @@ export type {
     BaseRelationLineageResponseV1,
     InputRelationLineageResponseV1,
     IORelationSchemaFieldV1,
+    IORelationSchemaRelevanceTypeV1,
     IORelationSchemaV1,
     OutputRelationLineageResponseV1,
     OutputRelationTypeLineageResponseV1,

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -73,8 +73,14 @@ const customEnglishMessages: TranslationMessages = {
                     type: "Location Type",
                 },
                 schema: {
-                    input: "Input schema (projected) |||| Latest of %{smart_count} input schemas (projected)",
-                    output: "Output Schema |||| Latest of %{smart_count} output schemas",
+                    input: {
+                        exact_match: "Input schema projection",
+                        latest_known: "Input schema projection (latest)",
+                    },
+                    output: {
+                        exact_match: "Output schema",
+                        latest_known: "Output schema (latest)",
+                    },
                     field: {
                         name: "Field",
                         type: "Type",


### PR DESCRIPTION
Previously we counted unique number of output/input schemas, and used it to annotate dataset schema. Since https://github.com/MobileTeleSystems/data-rentgen/pull/185 backend includes field `relevance_type` which shows if returned schema is just one of many ones, so the count of schemas is not very useful.

Instead we just annotate is this schema one of many, or exactly one.