### PR TITLE
[DOP-24601] Add support for selecting RunNode/OperationNode by click

### DIFF
--- a/src/components/lineage/LineageGraph.tsx
+++ b/src/components/lineage/LineageGraph.tsx
@@ -10,7 +10,7 @@ import {
     Edge,
     Node,
 } from "@xyflow/react";
-import { DatasetNode, JobNode, RunNode, OperationNode } from "./nodes";
+import { DatasetNode, JobNode } from "./nodes";
 import { MouseEvent, useLayoutEffect } from "react";
 import { BaseEdge, IOEdge, ColumnLineageEdge } from "./edges";
 import useLineageSelectionProvider from "./selection/useLineageSelectionProvider";
@@ -34,8 +34,6 @@ const edgeTypes = {
 const nodeTypes = {
     datasetNode: DatasetNode,
     jobNode: JobNode,
-    runNode: RunNode,
-    operationNode: OperationNode,
 };
 
 const LineageGraph = (props: ReactFlowProps) => {
@@ -59,7 +57,7 @@ const LineageGraph = (props: ReactFlowProps) => {
 
     const onNodeClick = (e: MouseEvent, node: Node) => {
         setSelection({
-            nodeWithColumns: new Map([[node.id, new Set<string>()]]),
+            nodeWithHandles: new Map([[node.id, new Set<string>()]]),
             edges: new Set(),
         });
         e.stopPropagation();

--- a/src/components/lineage/edges/IOEdge.css
+++ b/src/components/lineage/edges/IOEdge.css
@@ -1,0 +1,3 @@
+.react-flow__edgelabel-renderer > div.selected {
+    z-index: 1;
+}

--- a/src/components/lineage/edges/IOEdge.tsx
+++ b/src/components/lineage/edges/IOEdge.tsx
@@ -13,7 +13,7 @@ import formatNumberApprox from "@/utils/numbers";
 import formatBytes from "@/utils/bytes";
 import { Card, Chip, Typography } from "@mui/material";
 
-import "./BaseEdge.css";
+import "./IOEdge.css";
 
 const IOEdge = ({
     id,

--- a/src/components/lineage/nodes/dataset_node/DatasetSchemaTable.tsx
+++ b/src/components/lineage/nodes/dataset_node/DatasetSchemaTable.tsx
@@ -25,13 +25,13 @@ import {
 } from "react";
 import { Search } from "@mui/icons-material";
 import { IORelationSchemaFieldV1 } from "@/dataProvider/types";
-import { paginateArray } from "../../utils/pagination";
+import { paginateArray } from "@/components/lineage/utils/pagination";
 import { fieldMatchesText, flattenFields } from "./utils";
 import {
-    getNearestColumnRelations,
-    getAllColumnRelations,
-} from "../../selection/utils/columnSelection";
-import LineageSelectionContext from "../../selection/LineageSelectionContext";
+    getNearestHandleRelations,
+    getAllHandleRelations,
+} from "@/components/lineage/selection/utils/handleSelection";
+import LineageSelectionContext from "@/components/lineage/selection/LineageSelectionContext";
 
 const DatasetSchemaTable = ({
     nodeId,
@@ -75,10 +75,10 @@ const DatasetSchemaTable = ({
 
     const { selection, setSelection } = useContext(LineageSelectionContext);
     const selectedFields =
-        selection.nodeWithColumns.get(nodeId) ?? new Map<string, Set<string>>();
+        selection.nodeWithHandles.get(nodeId) ?? new Set<string>();
 
     const onFieldClick = (e: MouseEvent, fieldName: string) => {
-        const selection = getNearestColumnRelations(
+        const selection = getNearestHandleRelations(
             getEdges(),
             nodeId,
             fieldName,
@@ -88,7 +88,7 @@ const DatasetSchemaTable = ({
     };
 
     const onFieldDoubleClick = (e: MouseEvent, fieldName: string) => {
-        const selection = getAllColumnRelations(getEdges(), nodeId, fieldName);
+        const selection = getAllHandleRelations(getEdges(), nodeId, fieldName);
         setSelection(selection);
         e.stopPropagation();
     };

--- a/src/components/lineage/nodes/job_node/JobNode.css
+++ b/src/components/lineage/nodes/job_node/JobNode.css
@@ -1,0 +1,8 @@
+.react-flow__node .runNode.selected,
+.react-flow__node .operationNode.selected {
+    background-color: #b4d1ff;
+    border-color: var(
+        --xy-selection-border,
+        var(--xy-selection-border-default)
+    );
+}

--- a/src/components/lineage/nodes/job_node/JobNode.tsx
+++ b/src/components/lineage/nodes/job_node/JobNode.tsx
@@ -9,6 +9,8 @@ import BaseNode from "../base_node/BaseNode";
 import { JobIconWithType } from "@/components/job";
 import RunNodeList from "../run_node/RunNodeList";
 
+import "./JobNode.css";
+
 export type JobNode = Node<JobResponseV1, "jobNode">;
 
 const JobNode = (props: NodeProps<JobNode>): ReactElement => {
@@ -51,7 +53,10 @@ const JobNode = (props: NodeProps<JobNode>): ReactElement => {
                                 smart_count: props.data.runs,
                             })}
                         </Typography>
-                        <RunNodeList nodeId={props.id} runs={props.data.runs} />
+                        <RunNodeList
+                            jobNodeId={props.id}
+                            runs={props.data.runs}
+                        />
                     </>
                 ) : null
             }

--- a/src/components/lineage/nodes/operation_node/OperationNodeList.tsx
+++ b/src/components/lineage/nodes/operation_node/OperationNodeList.tsx
@@ -5,16 +5,16 @@ import { OperationResponseV1 } from "@/dataProvider/types";
 import { IconButton, Stack, TablePagination, TextField } from "@mui/material";
 import OperationNode from "./OperationNode";
 import { Search } from "@mui/icons-material";
-import { paginateArray } from "../../utils/pagination";
+import { paginateArray } from "@/components/lineage/utils/pagination";
 import { operationMatchesText } from "./utils/operationMatchesText";
 import { useUpdateNodeInternals } from "@xyflow/react";
 
 const OperationNodeList = ({
-    nodeId,
+    jobNodeId,
     operations,
     defaultRowsPerPage = 5,
 }: {
-    nodeId: string;
+    jobNodeId: string;
     operations: OperationResponseV1[];
     defaultRowsPerPage?: number;
 }): ReactElement => {
@@ -22,7 +22,11 @@ const OperationNodeList = ({
         const operation = operations[0];
         return (
             // @ts-expect-error Not managed by ReactFlow
-            <OperationNode key={operation.id} data={operation} />
+            <OperationNode
+                jobNodeId={jobNodeId}
+                key={operation.id}
+                data={operation}
+            />
         );
     }
 
@@ -64,7 +68,7 @@ const OperationNodeList = ({
 
     useLayoutEffect(() => {
         // Re-render all edges connected to this node
-        updateNodeInternals(nodeId);
+        updateNodeInternals(jobNodeId);
     }, [page, rowsPerPage, showSearch, search]);
 
     return (
@@ -99,7 +103,11 @@ const OperationNodeList = ({
 
             {operationsToShow.map((operation) => (
                 // @ts-expect-error Not managed by ReactFlow
-                <OperationNode key={operation.id} data={operation} />
+                <OperationNode
+                    jobNodeId={jobNodeId}
+                    key={operation.id}
+                    data={operation}
+                />
             ))}
 
             <TablePagination

--- a/src/components/lineage/nodes/run_node/RunNodeList.tsx
+++ b/src/components/lineage/nodes/run_node/RunNodeList.tsx
@@ -5,16 +5,16 @@ import { RunResponseV1 } from "@/dataProvider/types";
 import { IconButton, Stack, TablePagination, TextField } from "@mui/material";
 import RunNode from "./RunNode";
 import { Search } from "@mui/icons-material";
-import { paginateArray } from "../../utils/pagination";
+import { paginateArray } from "@/components/lineage/utils/pagination";
 import { runMatchesText } from "./utils/runMatchesText";
 import { useUpdateNodeInternals } from "@xyflow/react";
 
 const RunNodeList = ({
-    nodeId,
+    jobNodeId,
     runs,
     defaultRowsPerPage = 10,
 }: {
-    nodeId: string;
+    jobNodeId: string;
     runs: RunResponseV1[];
     defaultRowsPerPage?: number;
 }): ReactElement => {
@@ -22,7 +22,7 @@ const RunNodeList = ({
         const run = runs[0];
         return (
             // @ts-expect-error Not managed by ReactFlow
-            <RunNode key={run.id} data={run} />
+            <RunNode jobNodeId={jobNodeId} key={run.id} data={run} />
         );
     }
 
@@ -56,7 +56,7 @@ const RunNodeList = ({
 
     useLayoutEffect(() => {
         // Re-render all edges connected to this node
-        updateNodeInternals(nodeId);
+        updateNodeInternals(jobNodeId);
     }, [page, rowsPerPage, showSearch, search]);
 
     return (
@@ -91,7 +91,7 @@ const RunNodeList = ({
 
             {runsToShow.map((run) => (
                 // @ts-expect-error Not managed by ReactFlow
-                <RunNode key={run.id} data={run} />
+                <RunNode jobNodeId={jobNodeId} key={run.id} data={run} />
             ))}
 
             <TablePagination

--- a/src/components/lineage/selection/LineageSelectionContext.tsx
+++ b/src/components/lineage/selection/LineageSelectionContext.tsx
@@ -3,7 +3,7 @@ import { LineageSelection } from "./utils/common";
 
 const LineageSelectionValue = {
     selection: {
-        nodeWithColumns: new Map<string, Set<string>>(),
+        nodeWithHandles: new Map<string, Set<string>>(),
         edges: new Set<string>(),
     },
     setSelection: (newValue: LineageSelection): void => {},

--- a/src/components/lineage/selection/useLineageSelectionProvider.tsx
+++ b/src/components/lineage/selection/useLineageSelectionProvider.tsx
@@ -6,7 +6,7 @@ const useLineageSelectionProvider = () => {
     const { getNodes, setNodes, getEdges, setEdges } = useReactFlow();
 
     const [selection, setSelectionState] = useState<LineageSelection>({
-        nodeWithColumns: new Map<string, Set<string>>(),
+        nodeWithHandles: new Map<string, Set<string>>(),
         edges: new Set<string>(),
     });
 
@@ -15,7 +15,7 @@ const useLineageSelectionProvider = () => {
         const newNodes = getNodes().map((node) => {
             return {
                 ...node,
-                selected: newValue.nodeWithColumns.has(node.id),
+                selected: newValue.nodeWithHandles.has(node.id),
             };
         });
         const newEdges = getEdges().map((edge) => {
@@ -30,7 +30,7 @@ const useLineageSelectionProvider = () => {
 
     const resetSelection = useCallback(() => {
         setSelectionState({
-            nodeWithColumns: new Map<string, Set<string>>(),
+            nodeWithHandles: new Map<string, Set<string>>(),
             edges: new Set<string>(),
         });
     }, []);

--- a/src/components/lineage/selection/utils/edgeSelection.ts
+++ b/src/components/lineage/selection/utils/edgeSelection.ts
@@ -7,10 +7,10 @@ import {
 } from "./common";
 
 export const getNearestEdgeRelations = (edge: Edge): LineageSelection => {
-    // For specific edge return connected nodes and columns (if any).
+    // For specific edge return connected nodes and handles (if any).
 
     return {
-        nodeWithColumns: new Map<string, Set<string>>([
+        nodeWithHandles: new Map<string, Set<string>>([
             [
                 edge.source,
                 new Set([edge.sourceHandle].filter((field) => field != null)),
@@ -32,8 +32,8 @@ export const getAllEdgeRelations = (
 
     const { edgesBySource, edgesByTarget } = splitEdges(edges);
 
-    // walk `source -> edge -> target`
-    // for columnLineageEdge, select nodes and columns connected to it
+    // walk `source -> edge -> target`, recursively,
+    // keep in mind handle name of the edge
     const downstreams = getAllConnections(
         edge.target,
         new Set([edge.targetHandle].filter((field) => field != null)),

--- a/src/components/lineage/selection/utils/handleSelection.ts
+++ b/src/components/lineage/selection/utils/handleSelection.ts
@@ -6,65 +6,65 @@ import {
     splitEdges,
 } from "./common";
 
-export const getNearestColumnRelations = (
+export const getNearestHandleRelations = (
     edges: Edge[],
     nodeId: string,
-    fieldName: string,
+    handle: string,
 ): LineageSelection => {
-    // For specific node and column return only nearest edges and their columns.
+    // For specific node and handle return only nearest edges and their handles.
 
     const connectedEdges = edges.filter(
         (edge) =>
-            (edge.source === nodeId && edge.sourceHandle === fieldName) ||
-            (edge.target === nodeId && edge.targetHandle === fieldName),
+            (edge.source === nodeId && edge.sourceHandle === handle) ||
+            (edge.target === nodeId && edge.targetHandle === handle),
     );
 
     const result: LineageSelection = {
-        nodeWithColumns: new Map(),
+        nodeWithHandles: new Map(),
         edges: new Set(connectedEdges.map((edge) => edge.id)),
     };
 
     connectedEdges.forEach((edge) => {
-        const columns =
-            result.nodeWithColumns.get(edge.source) ?? new Set<string>();
+        const handles =
+            result.nodeWithHandles.get(edge.source) ?? new Set<string>();
         if (edge.sourceHandle) {
-            columns.add(edge.sourceHandle);
+            handles.add(edge.sourceHandle);
         }
-        result.nodeWithColumns.set(edge.source, columns);
+        result.nodeWithHandles.set(edge.source, handles);
     });
 
     connectedEdges.forEach((edge) => {
-        const columns =
-            result.nodeWithColumns.get(edge.target) ?? new Set<string>();
+        const handles =
+            result.nodeWithHandles.get(edge.target) ?? new Set<string>();
         if (edge.targetHandle) {
-            columns.add(edge.targetHandle);
+            handles.add(edge.targetHandle);
         }
-        result.nodeWithColumns.set(edge.target, columns);
+        result.nodeWithHandles.set(edge.target, handles);
     });
 
     return result;
 };
 
-export const getAllColumnRelations = (
+export const getAllHandleRelations = (
     edges: Edge[],
     nodeId: string,
-    fieldName: string,
+    handle: string,
 ): LineageSelection => {
-    // For specific node and column return all connected edges and nodes, recursively.
+    // For specific node and handle return all connected edges and nodes, recursively.
 
     const { edgesBySource, edgesByTarget } = splitEdges(edges);
 
     // walk `source -> edge - target`
     const downstreams = getAllConnections(
         nodeId,
-        new Set([fieldName]),
+        new Set([handle]),
         edgesBySource,
         "outgoing",
     );
     // same, but in opposite direction
     const upstreams = getAllConnections(
         nodeId,
-        new Set([fieldName]),
+        new Set([handle]),
         edgesByTarget,
         "incoming",
     );

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -204,6 +204,9 @@ const customEnglishMessages: TranslationMessages = {
                 },
                 apply_button: "Apply",
             },
+            pagination: {
+                all: "All",
+            },
         },
         operations: {
             name: "Operation |||| Operations",
@@ -265,6 +268,9 @@ const customEnglishMessages: TranslationMessages = {
                     label: "Search",
                     helperText: "Filter by name, group or description",
                 },
+            },
+            pagination: {
+                all: "All",
             },
         },
     },


### PR DESCRIPTION
Before clicking on any run or operation within JobNode selected the whole JobNode.
![image](https://github.com/user-attachments/assets/232e9c8c-9c8f-426e-af96-fcc5197e77e7)
![image](https://github.com/user-attachments/assets/1dc6aece-b50c-44d7-ad0a-04cab6d32465)

Now clicking on RunNode/OperationNode selects only this node and connected edges:
![image](https://github.com/user-attachments/assets/28bd11e0-6fb8-49eb-b1f0-6b99d753bcd2)
![image](https://github.com/user-attachments/assets/8cbf4fab-95ad-427b-b89a-191ded2bb378)

Double click selects connected nodes and edges recursively:
![image](https://github.com/user-attachments/assets/f8b85349-727e-4592-9e44-8abc5074db85)


Implementation just the same as for DatasetNode + list of fields in dataset schema. So I've replaced everything related to `column` with more generic `handle` in selection helper functions.

Also previously selecting IO edge haven't increased label z-index:
![image](https://github.com/user-attachments/assets/9f7c9364-6b81-4418-ae51-668ac22c63ee)

Fixed:
![image](https://github.com/user-attachments/assets/5a38370d-b307-4e9a-9728-e4a55a5d792b)
