### PR TITLE
[DOP-25532] Make artificial column lineage for SYMLINK relations

### DIFF
--- a/src/components/lineage/converters/getGraphNodes.ts
+++ b/src/components/lineage/converters/getGraphNodes.ts
@@ -78,12 +78,12 @@ const getDataseNode = (
     }
 
     let hasColumnLineage = false;
-    if (raw_response.relations.direct_column_lineage?.length) {
+    if (raw_response.relations.direct_column_lineage.length) {
         hasColumnLineage = raw_response.relations.direct_column_lineage.some(
             (relation) =>
                 relation.from.id == node.id || relation.to.id == node.id,
         );
-    } else if (raw_response.relations.indirect_column_lineage?.length) {
+    } else if (raw_response.relations.indirect_column_lineage.length) {
         hasColumnLineage = raw_response.relations.indirect_column_lineage.some(
             (relation) =>
                 relation.from.id == node.id || relation.to.id == node.id,

--- a/src/dataProvider/types.ts
+++ b/src/dataProvider/types.ts
@@ -226,9 +226,8 @@ interface LineageRelationsResponseV1 {
     inputs: InputRelationLineageResponseV1[];
     outputs: OutputRelationLineageResponseV1[];
     symlinks: SymlinkRelationLineageResponseV1[];
-    // TODO: remove undefined after implementing these fields in backend API
-    direct_column_lineage?: DirectColumnLineageRelationLineageResponseV1[];
-    indirect_column_lineage?: IndirectColumnLineageRelationLineageResponseV1[];
+    direct_column_lineage: DirectColumnLineageRelationLineageResponseV1[];
+    indirect_column_lineage: IndirectColumnLineageRelationLineageResponseV1[];
 }
 
 interface LineageNodesResponseV1 {


### PR DESCRIPTION
Before - datasets connected via SYMLINK relation have separated column lineage (before SYMLINK and after SYMLINK):
![изображение](https://github.com/user-attachments/assets/342c8bba-306c-4c27-80d4-ac65f101585e)
![изображение](https://github.com/user-attachments/assets/73872255-6bd9-4376-9e3f-2c2a9c090df6)

After - added artificial field-field connections for each schema of both datasets, making column lineage less fractured:
![Снимок экрана_20250521_134849-1](https://github.com/user-attachments/assets/9426b31b-8a63-4b5b-a260-10aa3ecf5565)
![изображение](https://github.com/user-attachments/assets/41ff8318-ec38-4f68-9822-c4fb6621a53c)
