### PR TITLE
[DOP-26447] Add Hive support

### DIFF
--- a/src/components/icons.tsx
+++ b/src/components/icons.tsx
@@ -15,6 +15,61 @@ import PostgreSQLIcon from "@assets/icons/postgresql.svg?react";
 import TeradataIcon from "@assets/icons/teradata.svg?react";
 import DatasetIcon from "@assets/icons/dataset.svg?react";
 import DataRentgenIcon from "@assets/icons/data-rentgen.svg?react";
+import { ReactElement } from "react";
+import { Cloud, Computer, Public, QuestionMark } from "@mui/icons-material";
+
+const IconByName = ({ name }: { name: string }): ReactElement => {
+    const nameLower = name.toLowerCase().split(/[^a-z]/)[0];
+
+    switch (nameLower) {
+        case "airflow":
+            return <ApacheAirflowIcon />;
+        case "clickhouse":
+            return <ClickhouseIcon />;
+        case "dbt":
+            return <DBTIcon />;
+        case "flink":
+            return <ApacheFlinkIcon />;
+        case "greenplum":
+            return <GreenplumIcon />;
+        case "hive":
+            return <ApacheHiveIcon />;
+        case "kafka":
+            return <ApacheKafkaIcon />;
+        case "mongodb":
+            return <MongoDBIcon />;
+        case "mysql":
+            return <MySQLIcon />;
+        case "oracle":
+            return <OracleIcon />;
+        case "postgres":
+            return <PostgreSQLIcon />;
+        case "spark":
+            return <ApacheSparkIcon />;
+        case "sqlserver":
+            return <MSSQLServerIcon />;
+        case "teradata":
+            return <TeradataIcon />;
+        case "hdfs":
+        case "yarn":
+            return <ApacheHadoopIcon />;
+        case "ftp":
+        case "ftps":
+        case "sftp":
+        case "s3":
+        case "samba":
+        case "webdav":
+            return <Cloud />;
+        case "local":
+        case "file":
+            return <Computer />;
+        case "http":
+        case "https":
+            return <Public />;
+        default:
+            return <QuestionMark />;
+    }
+};
 
 export {
     ApacheAirflowIcon,
@@ -34,4 +89,5 @@ export {
     TeradataIcon,
     DatasetIcon,
     DataRentgenIcon,
+    IconByName,
 };

--- a/src/components/job/JobIcon.tsx
+++ b/src/components/job/JobIcon.tsx
@@ -1,27 +1,9 @@
 import { ReactElement } from "react";
-import {
-    ApacheAirflowIcon,
-    ApacheSparkIcon,
-    ApacheFlinkIcon,
-    DBTIcon,
-} from "@/components/icons";
+import { IconByName } from "@/components/icons";
 import { JobResponseV1 } from "@/dataProvider/types";
-import { QuestionMark } from "@mui/icons-material";
 
 const JobIcon = ({ job }: { job: JobResponseV1 }): ReactElement => {
-    if (job.type.startsWith("SPARK")) {
-        return <ApacheSparkIcon />;
-    }
-    if (job.type.startsWith("AIRFLOW")) {
-        return <ApacheAirflowIcon />;
-    }
-    if (job.type.startsWith("FLINK")) {
-        return <ApacheFlinkIcon />;
-    }
-    if (job.type.startsWith("DBT")) {
-        return <DBTIcon />;
-    }
-    return <QuestionMark />;
+    return <IconByName name={job.type} />;
 };
 
 export default JobIcon;

--- a/src/components/job/JobType.tsx
+++ b/src/components/job/JobType.tsx
@@ -5,7 +5,14 @@ const JobType = ({ job }: { job: JobResponseV1 }): string => {
     const translate = useTranslate();
 
     return translate(`resources.jobs.types.${job.type.toLocaleLowerCase()}`, {
-        _: job.type,
+        _: job.type
+            .split("_")
+            .map(
+                (s) =>
+                    s.charAt(0).toLocaleUpperCase() +
+                    s.substring(1).toLocaleLowerCase(),
+            )
+            .join(" "),
     });
 };
 

--- a/src/components/location/LocationIcon.tsx
+++ b/src/components/location/LocationIcon.tsx
@@ -1,64 +1,13 @@
 import { ReactElement } from "react";
-import {
-    ApacheHadoopIcon,
-    ApacheHiveIcon,
-    ApacheKafkaIcon,
-    ClickhouseIcon,
-    GreenplumIcon,
-    MongoDBIcon,
-    MSSQLServerIcon,
-    MySQLIcon,
-    OracleIcon,
-    PostgreSQLIcon,
-    TeradataIcon,
-} from "@/components/icons";
+import { IconByName } from "@/components/icons";
 import { LocationResponseV1 } from "@/dataProvider/types";
-import { Cloud, Computer, Public, QuestionMark } from "@mui/icons-material";
 
 const LocationIcon = ({
     location,
 }: {
     location: LocationResponseV1;
 }): ReactElement => {
-    switch (location.type) {
-        case "clickhouse":
-            return <ClickhouseIcon />;
-        case "greenplum":
-            return <GreenplumIcon />;
-        case "hive":
-            return <ApacheHiveIcon />;
-        case "kafka":
-            return <ApacheKafkaIcon />;
-        case "mongodb":
-            return <MongoDBIcon />;
-        case "mysql":
-            return <MySQLIcon />;
-        case "oracle":
-            return <OracleIcon />;
-        case "postgres":
-            return <PostgreSQLIcon />;
-        case "sqlserver":
-            return <MSSQLServerIcon />;
-        case "teradata":
-            return <TeradataIcon />;
-        case "hdfs":
-        case "yarn":
-            return <ApacheHadoopIcon />;
-        case "ftp":
-        case "ftps":
-        case "sftp":
-        case "s3":
-        case "samba":
-        case "webdav":
-            return <Cloud />;
-        case "local":
-            return <Computer />;
-        case "http":
-        case "https":
-            return <Public />;
-        default:
-            return <QuestionMark />;
-    }
+    return <IconByName name={location.type} />;
 };
 
 export default LocationIcon;

--- a/src/i18n/en.ts
+++ b/src/i18n/en.ts
@@ -110,9 +110,10 @@ const customEnglishMessages: TranslationMessages = {
             types: {
                 airflow_task: "Airflow Task",
                 airflow_dag: "Airflow DAG",
-                spark_application: "Spark Application",
                 flink_job: "Flink Job",
                 dbt_job: "DBT Job",
+                hive_session: "Hive Session",
+                spark_application: "Spark Application",
             },
             fields: {
                 id: "Internal ID",

--- a/src/i18n/ru.ts
+++ b/src/i18n/ru.ts
@@ -110,9 +110,10 @@ const customRussianMessages: TranslationMessages = {
             types: {
                 airflow_task: "Airflow Task",
                 airflow_dag: "Airflow DAG",
-                spark_application: "Spark Application",
                 flink_job: "Flink Job",
                 dbt_job: "DBT Job",
+                hive_session: "Hive Session",
+                spark_application: "Spark Application",
             },
             fields: {
                 id: "Внутренний идентификатор",


### PR DESCRIPTION
* Add translation item for `HIVE_SESSION`.
* Ad now we have integrations which are both Job type and Dataset location (e.g. Hive, Oracle), I've combined logic of fetching icon by external system name into `IconByName` component.

![Снимок экрана_20250620_181536](https://github.com/user-attachments/assets/66fc40e7-dc49-4545-be19-f16f34841dbf)
